### PR TITLE
DOC-362 Standardize authorization token placeholders

### DIFF
--- a/artificial-intelligence/ai-rag-indexer/ai-rag-indexer-tutorial.md
+++ b/artificial-intelligence/ai-rag-indexer/ai-rag-indexer-tutorial.md
@@ -64,35 +64,35 @@ When you already know which fields you can index, call the [Listing fields for v
 
 ```bash
 curl --location --globoff --request PUT 'https://api.emporix.io/ai-service/{tenant}/agentic/tools/{toolId}' 
---header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
---header 'Content-Type: application/json' 
---data '{
-  "id": "rag-product",
-  "name": "Product Search RAG Tool",
-  "type": "rag_emporix",
-  "config": {
-        "entityType": "product",
-        "embeddingConfig": {
-            "provider": "emporix_openai"
-        },
-        "prompt": "You are a search tool for searching products",
-        "indexedFields": [
-            {
-                "name": "",
-                "key": "code"
-            },
-                        {
-                "name": "",
-                "key": "name.en"
-            },
-                        {
-                "name": "",
-                "key": "description.en"
-            }
-        ]
-    },
-    "enabled": true
-}'
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
+  --header 'Content-Type: application/json' 
+  --data '{
+    "id": "rag-product",
+    "name": "Product Search RAG Tool",
+    "type": "rag_emporix",
+    "config": {
+          "entityType": "product",
+          "embeddingConfig": {
+              "provider": "emporix_openai"
+          },
+          "prompt": "You are a search tool for searching products",
+          "indexedFields": [
+              {
+                  "name": "",
+                  "key": "code"
+              },
+                          {
+                  "name": "",
+                  "key": "name.en"
+              },
+                          {
+                  "name": "",
+                  "key": "description.en"
+              }
+          ]
+      },
+      "enabled": true
+  }'
 ```
 
 {% include "../../.gitbook/includes/example-hint-text.md" %}

--- a/artificial-intelligence/ai-rag-indexer/ai-rag-indexer-tutorial.md
+++ b/artificial-intelligence/ai-rag-indexer/ai-rag-indexer-tutorial.md
@@ -38,7 +38,7 @@ Call the [Listing fields for RAG search](https://developer.emporix.io/api-refere
 curl -L 
   --request GET 
   --url 'https://api.emporix.io/ai-rag-indexer/{tenant}/{type}/rag-metadata' 
-  --header 'Authorization: Bearer <ACCESS_TOKEN>' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: application/json'
 ```
 
@@ -64,7 +64,7 @@ When you already know which fields you can index, call the [Listing fields for v
 
 ```bash
 curl --location --globoff --request PUT 'https://api.emporix.io/ai-service/{tenant}/agentic/tools/{toolId}' 
---header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+--header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
 --header 'Content-Type: application/json' 
 --data '{
   "id": "rag-product",
@@ -111,7 +111,7 @@ When the tool is ready, call the [Reindexing the entities of given type](https:/
 curl -L 
   --request POST 
   --url 'https://api.emporix.io/ai-rag-indexer/{tenant}/{type}/reindex' 
-  --header 'Authorization: Bearer <ACCESS_TOKEN>' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 

--- a/artificial-intelligence/ai-service/ai-tutorial.md
+++ b/artificial-intelligence/ai-service/ai-tutorial.md
@@ -60,7 +60,7 @@ You can generate the text by sending a request based on a provided prompt. To se
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/ai-service/{tenant}/texts' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "id": "en",
@@ -82,7 +82,7 @@ Completion is generated based on chat history. It's a generated response or cont
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/ai-service/{tenant}/completions' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "id": "abc-123",
@@ -282,7 +282,7 @@ Collect the `agentIds` you want to export, then call the [Exporting agents](http
 curl -L \
   --request POST \
   --url 'https://api.emporix.io/ai-service/{tenant}/agentic/agents/export' \
-  --header 'Authorization: Bearer <YOUR_TOKEN_HERE>' \
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
   --header 'Content-Type: application/json' \
   --data '{
     "agentIds": [
@@ -309,7 +309,7 @@ Use the payload obtained during export and call the [Importing agents](https://d
 curl -L \
   --request POST \
   --url 'https://api.emporix.io/ai-service/{tenant}/agentic/agents/import' \
-  --header 'Authorization: Bearer <YOUR_TOKEN_HERE>' \
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
   --header 'Content-Type: application/json' \
   --data '{
     "data": "<BASE64_PAYLOAD_FROM_EXPORT>",

--- a/authentication/oauth-service/oauth.md
+++ b/authentication/oauth-service/oauth.md
@@ -101,7 +101,7 @@ A successful response returns a JSON object containing the access token and meta
 Use the token in subsequent API calls by setting the `Authorization` header:
 
 ```text
-Authorization: Bearer <access_token>
+Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}
 ```
 {% endstep %}
 {% endstepper %}

--- a/catalogs-and-categories/catalog/catalog.md
+++ b/catalogs-and-categories/catalog/catalog.md
@@ -44,7 +44,7 @@ To create a new catalog, you need to send a request to the [Creating a new catal
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/catalog/{tenant}/catalogs' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
   "name": {
@@ -84,7 +84,7 @@ For more information, check out [_How to create a category_](../category-tree/ca
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/category/{tenant}/categories?publish=true' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: `*`, `en`, `en,de,fr`, `en-EN`, `fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7`' 
   -H 'Content-Type: application/json' 
   -H 'X-Version: v2' 
@@ -132,7 +132,7 @@ In the request body, insert the ID of the category into the `categoryIds` array.
 ```bash
 curl -i -X PATCH 
   'https://api.emporix.io/catalog/{tenant}/catalogs/{catalogId}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "name": {

--- a/checkout/cart/cart.md
+++ b/checkout/cart/cart.md
@@ -38,7 +38,7 @@ To create a new cart, send a request to the [Creating a new cart](https://develo
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/cart/{tenant}/carts' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -H 'saas-token: string' 
   -H 'session-id: string' 
@@ -102,7 +102,7 @@ To add custom attributes to a cart, send a request to the [Updating a cart](http
 ```bash
 curl -i -X PUT 
   'https://api.emporix.io/cart/{tenant}/carts/{cartId}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
   "customerId": "87413250",
@@ -158,7 +158,7 @@ To merge an anonymous cart with a customer cart, send a request to the [Merging 
 curl -i -X POST \
   'https://api.emporix.io/cart/{tenant}/carts/{cartId}/merge' 
   -H 'Accept-Language: string' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -H 'languages: string' 
@@ -201,7 +201,7 @@ Once external pricing is enabled, you can add a product that is available within
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/cart/{tenant}/carts/{cartId}/items?siteCode=string' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "itemYrn": "urn:yaas:saasag:caasproduct:product:mytenant;1600A016BF",
@@ -251,7 +251,7 @@ To add a product outside Commerce Engine, send the request to the Adding a produ
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/cart/{tenant}/carts/{cartId}/items?siteCode={siteCode}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "itemYrn": null,
@@ -302,7 +302,7 @@ To add a custom fee to the cart, send the request to the [Adding a product to ca
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/cart/{tenant}/carts/{cartId}/items?siteCode=string' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "itemYrn": "{productYrn}",
@@ -353,7 +353,7 @@ To apply an external discount to a cart, use the `externalDiscounts` attribute w
 curl -L 
   --request PUT 
   --url 'https://api.emporix.io/cart/{tenant}/carts/{cartId}' 
-  --header 'Authorization: Bearer YOUR_SECRET_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '{
     "externalDiscounts": [
@@ -403,7 +403,7 @@ Use the `externalDiscounts` attribute when adding an item to the cart or updatin
 curl -L 
   --request POST 
   --url 'https://api.emporix.io/cart/{tenant}/carts/{cartId}/items?siteCode=text' 
-  --header 'Authorization: Bearer YOUR_SECRET_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '{
     "externalDiscounts": [
@@ -2204,7 +2204,7 @@ Make sure the shipping zone is properly stored in the delivery times object.
 ```bash
 curl -L 
   --url 'https://api.emporix.io/shipping/{tenant}/actualDeliveryWindows/{cartId}' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 {% endstep %}
@@ -2218,7 +2218,7 @@ Pick the delivery window you'd like to use and update the cart accordingly by ca
 curl -L 
   --request PUT 
   --url 'https://api.emporix.io/cart/{tenant}/carts/{cartId}' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '{
         "countryCode": "DE",     
@@ -2241,7 +2241,7 @@ Verify the results by retrieving the cart. Call the [Retrieving cart details by 
 ```bash
 curl -L 
   --url 'https://api.emporix.io/cart/{tenant}/carts/{cartId}'
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN'
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
   --header 'Accept: */*'
 ```
 {% endstep %}

--- a/checkout/checkout/checkout.md
+++ b/checkout/checkout/checkout.md
@@ -87,7 +87,7 @@ Send a request to the [Creating a new tax configuration](https://developer.empor
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/tax/{tenant}/taxes' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -145,7 +145,7 @@ Send a request to the [Creating a shipping zone](https://developer.emporix.io/ap
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/shipping/{tenant}/{site}/zones' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: fr' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -170,7 +170,7 @@ Send a request to the [Creating a shipping method](https://developer.emporix.io/
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/shipping/{tenant}/{site}/zones/{zoneId}/methods' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: fr' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -227,7 +227,7 @@ The delivery time is matched with the delivery method and zone by sending the re
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/shipping/{tenant}/delivery-times?validateOverlap=true' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "siteCode": "main",
@@ -277,7 +277,7 @@ Send the request to the [Creating multiple products](https://developer.emporix.i
 curl -L 
   --request POST 
   --url 'https://api.emporix.io/product/{tenant}/products/bulk' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '[
     {
@@ -322,7 +322,7 @@ Send a request to the [Creating a new price model](https://developer.emporix.io/
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/price/{tenant}/priceModels' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -357,7 +357,7 @@ Send a request to the [Creating a new price](https://developer.emporix.io/api-re
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/price/{tenant}/prices' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -402,7 +402,7 @@ Allow your customers find the best price based on information retrieved from the
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/price/{tenant}/match-prices-by-context' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "items": [
@@ -445,7 +445,7 @@ Creating a cart takes care of things like gathering customer's session details, 
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/cart/{tenant}/carts' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -H 'saas-token: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI2MTQ0MzU2MyIsImV4cCI6MTY5Nzk3MDUyOH0.F0b5jr6KeSoBCj-suTLuasmydaJEudc1ZrESkQXSCGk' 
   -H 'session-id: string' 
@@ -471,7 +471,7 @@ curl -i -X POST
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/cart/{tenant}/carts' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -H 'saas-token: string' 
   -H 'session-id: string' 
@@ -496,7 +496,7 @@ Send a request to the [Creating a new cart](https://developer.emporix.io/api-ref
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/cart/{tenant}/carts/{cartId}/items?siteCode=string' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "itemYrn": "{productYrn}",
@@ -550,7 +550,7 @@ Send a request to the [Triggering a checkout](https://developer.emporix.io/api-r
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/checkout/{tenant}/checkouts/order' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -H 'saas-token: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI2MTQ0MzU2MyIsImV4cCI6MTY5Nzk3MDUyOH0.F0b5jr6KeSoBCj-suTLuasmydaJEudc1ZrESkQXSCGk' \
   -d '{

--- a/checkout/fee/fee.md
+++ b/checkout/fee/fee.md
@@ -48,7 +48,7 @@ Send the request to the [Creating a fee](https://developer.emporix.io/api-refere
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/fee/{tenant}/fees' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -81,7 +81,7 @@ To add the fee to the specific product, send the request to the [Adding a list o
 ```bash
 curl -i -X PUT 
   'https://api.emporix.io/fee/{tenant}/productFees/{productId}/fees?siteCode=main&partial=false' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "feeIds": [
@@ -103,7 +103,7 @@ To make sure the fee has been added properly, you can send the request to the [R
 curl -i -X GET 
   'https://api.emporix.io/fee/{tenant}/productFees/{productId}/fees?siteCode=main&expand=false' 
   -H 'Accept-Language: *' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 In the query parameter, provide the `siteCode` of the specific site the fee was applied to, for example `?siteCode=DE`.
@@ -113,7 +113,7 @@ Or, you can check if the fee was applied by sending the request to the [Searchin
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/fee/{tenant}/itemFees/searchByProductId' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "productId": "Apple_A_productId",
@@ -146,7 +146,7 @@ Send the request to the [Creating a fee](https://developer.emporix.io/api-refere
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/fee/{tenant}/fees' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -179,7 +179,7 @@ To connect the fee to the specific payment type, create the item fee by sending 
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/fee/{tenant}/itemFees' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application:json' 
   -d '[object Object]'
@@ -196,7 +196,7 @@ Send a request to the [Adding a list of fees to an item](https://developer.empor
 ```bash
 curl -i -X PUT 
   'https://api.emporix.io/fee/{tenant}/itemFees/{itemYRN}/fees?partial=false' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "feeIds": [
@@ -219,7 +219,7 @@ Send the request to the [Checking of a fee has been applied](https://developer.e
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/fee/{tenant}/itemFees/search?siteCode=main' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "itemYrns": [

--- a/companies-and-customers/approval-service/approval.md
+++ b/companies-and-customers/approval-service/approval.md
@@ -195,7 +195,7 @@ You can check the approval rights either with IAM or Approval service.
 ```bash
 curl -L 
   --url 'https://api.emporix.io/iam/{tenant}/users/{userId}/groups' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 
@@ -216,7 +216,7 @@ Send the request to the [Retrieving users assigned to a group](https://developer
 ```bash
 curl -L 
   --url 'https://api.emporix.io/iam/{tenant}/groups/{groupId}/users' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 
@@ -238,7 +238,7 @@ If a customer is in `B2B_ADMIN` role, the create approval flow does not start.
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/approval/{tenant}/approvals' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "id": "64e241ced632aa413a27a318",
@@ -318,7 +318,7 @@ To update an approval, send a request to the [Updating a single approval](https:
 ```bash
 curl -i -X PATCH 
   'https://api.emporix.io/approval/{tenant}/approvals/{approvalId}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
 ```
 
@@ -337,7 +337,7 @@ To retrieve an approval, send a request to the [Retrieving a single approval](ht
 ```bash
 curl -i -X GET 
   'https://api.emporix.io/approval/{tenant}/approvals/{approvalId}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 ## FAQ

--- a/companies-and-customers/client-management/customer-management.md
+++ b/companies-and-customers/client-management/customer-management.md
@@ -53,7 +53,7 @@ A location is a physical address where a company operates, such as its headquart
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/customer-management/{tenant}/locations' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "name": "Main HQ",
@@ -97,7 +97,7 @@ A legal entity is a representation of a company. To add a new legal entity, send
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/customer-management/{tenant}/legal-entities' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "name": "ABC Company",
@@ -167,7 +167,7 @@ The `id` from the response is further referred to as `parentId`.
 ```bash
 curl -i -X GET 
   'https://api.emporix.io/customer-management/{tenant}/legal-entities?pageNumber=1&pageSize=16&sort=name%2Cmetadata.createdAt%3Adesc&q=name%3A~john&fields=name%2Ctype&id=string&name=string&type=COMPANY&parentId=string&legalInfo.legalName=string&legalInfo.registrationDate=string&legalInfo.taxRegistrationNumber=string&legalInfo.registrationAgency=string&legalInfo.countryOfRegistration=string&legalInfo.registrationId=string' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'X-Total-Count: false'
 ```
 
@@ -184,7 +184,7 @@ Subsidiaries are added similarly to their parent companies. To add a new subsidi
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/customer-management/{tenant}/legal-entities' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "name": "ABC Subsidiary",
@@ -264,7 +264,7 @@ To find out what a company ID is, send a request to the [Retrieving all legal en
 ```bash
 curl -i -X GET 
   'https://api.emporix.io/customer-management/{tenant}/legal-entities?pageNumber=1&pageSize=16&sort=name%2Cmetadata.createdAt%3Adesc&q=name%3A~john&fields=name%2Ctype&id=string&name=string&type=COMPANY&parentId=string&legalInfo.legalName=string&legalInfo.registrationDate=string&legalInfo.taxRegistrationNumber=string&legalInfo.registrationAgency=string&legalInfo.countryOfRegistration=string&legalInfo.registrationId=string' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'X-Total-Count: false'
 ```
 
@@ -285,7 +285,7 @@ To retrieve an employee's customer ID, send a request to the [Retrieving a list 
 ```bash
 curl -i -X GET 
   'https://api.emporix.io/customer/{tenant}/customers?q=contactEmail%3A{email}&sort=string&pageNumber=1&pageSize=60&expand=string' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 {% hint style="warning" %}
@@ -305,7 +305,7 @@ A contact represents an employee of one or more business customers. To assign a 
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/customer-management/{tenant}/contact-assignments' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "legalEntity": {

--- a/companies-and-customers/customer-management/api-reference/api.yml
+++ b/companies-and-customers/customer-management/api-reference/api.yml
@@ -965,7 +965,7 @@ paths:
           required: true
           schema:
             type: string
-          example: "Bearer {customer_access_token}"
+          example: "Bearer {{CUSTOMER_ACCESS_TOKEN}}"
         - name: refreshToken
           in: query
           description: Customer refresh token generated when a customer token is requested.
@@ -1007,7 +1007,7 @@ paths:
           required: true
           schema:
             type: string
-          example: "Bearer {customer_access_token}"
+          example: "Bearer {{CUSTOMER_ACCESS_TOKEN}}"
       responses:
         "200":
           description: The request was successful. A token details are returned.

--- a/companies-and-customers/customer-management/customer-management-tutorial.md
+++ b/companies-and-customers/customer-management/customer-management-tutorial.md
@@ -93,7 +93,7 @@ To create a new customer account, send a request to the [Creating a new customer
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/customer/{tenant}/signup' 
-  -H 'Authorization: Bearer {anonymous_access_token}' 
+  -H 'Authorization: Bearer {{ANONYMOUS_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "email": "example@customer.com",
@@ -158,7 +158,7 @@ Send the `PATCH` request for [Updating a customer profile](https://developer.emp
 
 ```bash
 curl -X PATCH "https://api.emporix.io/customer/{tenant}/customers/{customerNumber}" 
-  -H "Authorization: Bearer YOUR_OAUTH2_TOKEN" 
+  -H "Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}" 
   -H "Content-Type: application/json" 
   -d '{
     "active": true,
@@ -180,7 +180,7 @@ Send an authorization request to the [Logging in a customer](https://developer.e
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/customer/{tenant}/login' 
-  -H 'Authorization: Bearer {anonymous_access_token}' 
+  -H 'Authorization: Bearer {{ANONYMOUS_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "email": "customer@customer.com",
@@ -221,7 +221,7 @@ Authorize the request with the anonymous access token.
 ```bash
 curl -i -X GET \
   'https://api.emporix.io/customer/{tenant}/refreshauthtoken?refreshToken={customer_refresh_token}&legalEntityId={legalEntityId}' \
-  -H 'Authorization: Bearer {anonymous_access_token}'
+  -H 'Authorization: Bearer {{ANONYMOUS_ACCESS_TOKEN}}'
 ```
 
 {% hint style="info" %}
@@ -243,7 +243,7 @@ Authorize the request with the customer access token.
 ```bash
 curl -i -X GET \
   'https://api.emporix.io/customer/{tenant}/validateauthtoken' \
-  -H 'Authorization: Bearer {customer_access_token}'
+  -H 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}'
 ```
 
 The response includes the details about the token type and granted scopes, for example:
@@ -278,7 +278,7 @@ Authorize the request with the anonymous access token.
 ```bash
 curl -i -X POST \
   'https://api.emporix.io/customer/{tenant}/socialLogin?code={authorization_code}&redirect_uri={redirect_uri}&code_verifier={code_verifier}' \
-  -H 'Authorization: Bearer {anonymous_access_token}' \
+  -H 'Authorization: Bearer {{ANONYMOUS_ACCESS_TOKEN}}' \
   -H 'session-id: {session_id}'
 ```
 The response returns the social access token to authenticate the customer.
@@ -317,8 +317,8 @@ Authorize the request with a customer access token.
 
 ```bash
 curl -i -X GET \
-  'https://api.emporix.io/customer/{tenant}/logout?accessToken={customer_access_token}' \
-  -H 'Authorization: Bearer {customer_access_token}'
+  'https://api.emporix.io/customer/{tenant}/logout?accessToken={{OAUTH2_ACCESS_TOKEN}}' \
+  -H 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}'
 ```
 
 {% hint style="info" %}
@@ -344,7 +344,7 @@ Authorize the request with a customer access token or an anonymous access token,
 ```bash
 curl -i -X GET 
   'https://api.emporix.io/customer/{tenant}/me?expand=addresses,mixin:*' 
-  -H 'Authorization: Bearer {customer_access_token}'
+  -H 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}'
 ```
 
 The response includes customer details such as personal information, preferred settings, and associated accounts:
@@ -403,7 +403,7 @@ Authorize the request with a customer access token.
 ```bash
 curl -i -X PATCH 
   'https://api.emporix.io/customer/{tenant}/me' 
-  -H 'Authorization: Bearer {customer_access_token}' 
+  -H 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "title": "MR",
@@ -437,7 +437,7 @@ Customers can add shipping or billing addresses to their profile. Send a request
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/customer/{tenant}/me/addresses' 
-  -H 'Authorization: Bearer {customer_access_token}' 
+  -H 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "contactName": "John Doe",
@@ -479,7 +479,7 @@ To retrieve all addresses associated with a customer profile, send a request to 
 ```bash
 curl -i -X GET 
   'https://api.emporix.io/customer/{tenant}/me/addresses' 
-  -H 'Authorization: Bearer {customer_access_token}'
+  -H 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}'
 ```
 The response returns an array of addresses:
 
@@ -520,7 +520,7 @@ Authorize the request with a customer access token.
 ```bash
 curl -i -X GET 
   'https://api.emporix.io/customer/{tenant}/me/addresses/{addressId}' 
-  -H 'Authorization: Bearer {customer_access_token}'
+  -H 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}'
 ```
 
 The response returns the address details:
@@ -556,7 +556,7 @@ To update an existing address, send a request to the [Updating a customer addres
 ```bash
 curl -i -X PATCH 
   'https://api.emporix.io/customer/{tenant}/me/addresses/{addressId}' 
-  -H 'Authorization: Bearer {customer_access_token}' 
+  -H 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "contactName": "John Doe",
@@ -591,7 +591,7 @@ To add tags to an existing address, send a request to the [Adding tags to a cust
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/customer/{tenant}/me/addresses/{addressId}/tags?tags=BILLING,SHIPPING,CUSTOM' 
-  -H 'Authorization: Bearer {customer_access_token}'
+  -H 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}'
 ```
 
 {% hint style="info" %}
@@ -607,7 +607,7 @@ To remove an address from a customer profile, send a request to the [Deleting a 
 ```bash
 curl -i -X DELETE 
   'https://api.emporix.io/customer/{tenant}/me/addresses/{addressId}' 
-  -H 'Authorization: Bearer {customer_access_token}'
+  -H 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}'
 ```
 
 {% hint style="warning" %}
@@ -640,7 +640,7 @@ Authorize the request with an anonymous access token.
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/customer/{tenant}/password/reset' 
-  -H 'Authorization: Bearer {anonymous_access_token}' 
+  -H 'Authorization: Bearer {{ANONYMOUS_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "email": "example@customer.com",
@@ -665,7 +665,7 @@ Authorize the request with the anonymous access token.
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/customer/{tenant}/password/reset/update' 
-  -H 'Authorization: Bearer {anonymous_access_token}' 
+  -H 'Authorization: Bearer {{ANONYMOUS_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "token": "beExUmshJC5gnuXk1kET5dCLyQWkrAfKRGFOxVXLcJI13R1fn5USjaWku5G71whM",
@@ -690,7 +690,7 @@ Authorize the request with a customer access token.
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/customer/{tenant}/password/change' 
-  -H 'Authorization: Bearer {customer_access_token}' 
+  -H 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "currentPassword": "password123",
@@ -715,7 +715,7 @@ Authorize the request with a customer access token.
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/customer/{tenant}/me/accounts/internal/email/change' 
-  -H 'Authorization: Bearer {customer_access_token}' 
+  -H 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "email": "example@customer.com",
@@ -742,7 +742,7 @@ Authorize the request with an anonymous access token.
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/customer/{tenant}/me/accounts/internal/email/change/confirm' 
-  -H 'Authorization: Bearer {anonymous_access_token}' 
+  -H 'Authorization: Bearer {{ANONYMOUS_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "token": "beExUmshJC5gnuXk1kET5dCLyQWkrAfKRGFOxVXLcJI13R1fn5USjaWku5G71whM"

--- a/companies-and-customers/customer-management/customer-management-tutorial.md
+++ b/companies-and-customers/customer-management/customer-management-tutorial.md
@@ -317,7 +317,7 @@ Authorize the request with a customer access token.
 
 ```bash
 curl -i -X GET \
-  'https://api.emporix.io/customer/{tenant}/logout?accessToken={{OAUTH2_ACCESS_TOKEN}}' \
+  'https://api.emporix.io/customer/{tenant}/logout?accessToken={{CUSTOMER_ACCESS_TOKEN}}' \
   -H 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}'
 ```
 

--- a/companies-and-customers/customer-segments/segments.md
+++ b/companies-and-customers/customer-segments/segments.md
@@ -32,7 +32,7 @@ Create a customer segment by sending a request to the the [Creating a customer s
 ```bash
 curl -i -X POST
   'https://api.emporix.io/customer-segment/{tenant}/segments'
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
   -H 'Content-Language: string'
   -H 'Content-Type: application/json'
   -d '{
@@ -68,7 +68,7 @@ Connect the segment with specific products and/or categories for more customized
 ```bash
 curl -i -X PUT
   'https://api.emporix.io/customer-segment/{tenant}/segments/{segmentId}/items/{type}/{itemId}'
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
   -H 'Content-Type: application/json'
   -d '{
     "mixins": {
@@ -95,7 +95,7 @@ curl -i -X PUT
 ```bash
 curl -i -X PUT
   'https://api.emporix.io/customer-segment/{tenant}/segments/{segmentId}/items/{type}/bulk'
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
   -H 'Content-Type: application/json'
   -d '{}'
 ```
@@ -119,7 +119,7 @@ Now, add customers to the segment. Depending on your setup and purpose, you can 
 ```bash
 curl -i -X PUT
   'https://api.emporix.io/customer-segment/{tenant}/segments/{segmentId}/customers/{customerId}/{legalEntityId}'
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
   -H 'Content-Type: application/json'
   -d '{
     "mixins": {
@@ -146,7 +146,7 @@ curl -i -X PUT
 ```bash
 curl -i -X PUT
   'https://api.emporix.io/customer-segment/{tenant}/segments/{segmentId}/customers/{customerId}/{legalEntityId}'
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
   -H 'Content-Type: application/json'
   -d '{
     "mixins": {
@@ -173,7 +173,7 @@ curl -i -X PUT
 ```bash
 curl -i -X PUT
   'https://api.emporix.io/customer-segment/{tenant}/segments/{segmentId}/customers/bulk'
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
   -H 'Content-Type: application/json'
   -d '{}'
 ```
@@ -198,7 +198,7 @@ You can use the search API to find a segment of your interest that match a speci
 curl -i -X POST
   'https://api.emporix.io/customer-segment/{tenant}/segments/search?pageSize=string&pageNumber=string&sort=string&fields=string&legalEntityId=string'
   -H 'Accept-Language: string'
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
   -H 'Content-Type: application/json'
   -H 'X-Total-Count: true'
   -d '{
@@ -222,7 +222,7 @@ To create a coupon that is valid only for a specific segment, send the request t
 ```bash
 curl -i -X POST
   'https://api.emporix.io/coupon/{tenant}/coupons'
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
   -H 'Content-Type: application/json'
   -d '{
     "code": "ENG2OC0",
@@ -277,7 +277,7 @@ Send the request to the [Retrieving all items assignments for all customer segme
 curl -i -X GET
   'https://api.emporix.io/customer-segment/{tenant}/segments/items?q=string&pageSize=string&pageNumber=string&sort=string&fields=string&legalEntityId=string&siteCode=string&onlyActive=false'
   -H 'Accept-Language: string'
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
   -H 'X-Total-Count: true'
 ```
 
@@ -298,7 +298,7 @@ Send the request to the [Retrieving category trees for a customer segments](http
 curl -i -X GET
   'https://api.emporix.io/customer-segment/{tenant}/segments/items/category-trees?legalEntityId=string&siteCode=string'
   -H 'Accept-Language: string'
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 The request generates a category tree with categories assigned to a segment and their parent categories, if applicable. If a segment specifies a subcategory only, the customer of that segment is able to see the parent category label, but content-wise, only the products from the subcategory are available.

--- a/companies-and-customers/customer-service/api-reference/customer-service-tenant.md
+++ b/companies-and-customers/customer-service/api-reference/customer-service-tenant.md
@@ -164,7 +164,7 @@ curl -X PATCH "https://api.emporix.io/customer/{tenant}/customers/{customerNumbe
 Verify the customer's details assigned to their profile by calling the [Retrieving a customer profile](https://developer.emporix.io/api-references/api-guides/companies-and-customers/customer-service/api-reference/account-and-profile#get-customer-tenant-customers-customernumber) endpoint.
 
 ```bash
-curl -X GET "https://api.emporix.io/customer/{tenant}/customers/{customerNimber}?expand=addresses,accounts" 
+curl -X GET "https://api.emporix.io/customer/{tenant}/customers/{customerNumber}?expand=addresses,accounts" 
   -H "Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}"
 ```
 

--- a/companies-and-customers/customer-service/api-reference/customer-service-tenant.md
+++ b/companies-and-customers/customer-service/api-reference/customer-service-tenant.md
@@ -49,7 +49,7 @@ Crete a new customer by calling the [Creating a customer](https://developer.empo
 
 ```bash
 curl -X POST "https://api.emporix.io/customer/{tenant}/customers?sendPasswordResetNotifications=true" 
-  -H "Authorization: Bearer YOUR_OAUTH2_TOKEN" 
+  -H "Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}" 
   -H "Content-Type: application/json" 
   -d '{
     "contactEmail": "john.doe@emporix.com",
@@ -83,7 +83,7 @@ For example, update the customer's email:
 
 ```bash
 curl -X PUT "https://api.emporix.io/customer/mytenant/customers/{customerNumber}" 
-  -H "Authorization: Bearer YOUR_OAUTH2_TOKEN" 
+  -H "Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}" 
   -H "Content-Type: application/json" 
   -d '{
     "contactEmail": "john.updated@emporix.com",
@@ -101,7 +101,7 @@ To add an address to the customer's profile, call the [Adding a customer address
 
 ```bash
 curl -X POST "https://api.emporix.io/customer/{tenant}/customers/{customerNumber}/addresses" 
-  -H "Authorization: Bearer YOUR_OAUTH2_TOKEN" 
+  -H "Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}" 
   -H "Content-Type: application/json" 
   -d '{
     "contactName": "John Doe",
@@ -135,7 +135,7 @@ To add any tags to the address for easier address management, send the request t
 
 ```bash
 curl -X POST "https://api.emporix.io/customer/{tenant}/customers/{customerNumber}/addresses/{addressId}/tags?tags=PRIMARY_CONTACT" \
-  -H "Authorization: Bearer YOUR_OAUTH2_TOKEN"
+  -H "Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}"
 ```
 
 {% hint style="info" %}
@@ -150,7 +150,7 @@ As the customer's account preparation is complete, activate their account. To do
 
 ```bash
 curl -X PATCH "https://api.emporix.io/customer/{tenant}/customers/{customerNumber}" 
-  -H "Authorization: Bearer YOUR_OAUTH2_TOKEN" 
+  -H "Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}" 
   -H "Content-Type: application/json" 
   -d '{
     "active": true,
@@ -165,7 +165,7 @@ Verify the customer's details assigned to their profile by calling the [Retrievi
 
 ```bash
 curl -X GET "https://api.emporix.io/customer/{tenant}/customers/{customerNimber}?expand=addresses,accounts" 
-  -H "Authorization: Bearer YOUR_OAUTH2_TOKEN"
+  -H "Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}"
 ```
 
 Example successful response includes all the assigned details:

--- a/companies-and-customers/vendor-service/vendor.md
+++ b/companies-and-customers/vendor-service/vendor.md
@@ -31,7 +31,7 @@ To create a vendor, send a request to the [Creating a vendor](https://developer.
 curl -L 
   --request POST 
   --url 'https://api.emporix.io/vendor/vendor/{tenant}/vendors' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '{
   "name": "ABC Company",
@@ -110,7 +110,7 @@ To set up a location for the vendor, send the request to the [Creating a locatio
 curl -L 
   --request POST 
   --url 'https://api.emporix.io/vendor/{tenant}/locations' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '{
   "name": "Example HQ",
@@ -234,7 +234,7 @@ A single user can belong to only one vendor group.
 curl -L 
   --request POST 
   --url 'https://api.emporix.io/iam/{tenant}/groups/{groupId}/users' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '{
     "userId": "3bf883fc-d18a-4175-8137-aaf64f810835",

--- a/configuration/configuration-service/configuration-service-tutorial.md
+++ b/configuration/configuration-service/configuration-service-tutorial.md
@@ -95,7 +95,7 @@ To retrieve a list of all tenant configurations, send a request to the [Retrievi
 ```bash
 curl -L 
   --url 'https://api.emporix.io/configuration/{tenant}/configurations' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 
@@ -104,7 +104,7 @@ You can also filter configurations by specific keys using the `keys` query param
 ```bash
 curl -L 
   --url 'https://api.emporix.io/configuration/{tenant}/configurations?keys=project_lang' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 
@@ -121,7 +121,7 @@ To retrieve a specific tenant configuration by its key, send a request to the [R
 ```bash
 curl -L 
   --url 'https://api.emporix.io/configuration/{tenant}/configurations/{propertyKey}' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 
@@ -130,7 +130,7 @@ curl -L
 ```bash
 curl -L 
   --url 'https://api.emporix.io/configuration/{tenant}/configurations/project_lang' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 
@@ -161,7 +161,7 @@ To create new tenant configurations, send a request to the [Creating configurati
 curl -L 
   --request POST 
   --url 'https://api.emporix.io/configuration/{tenant}/configurations' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '[
     {
@@ -185,7 +185,7 @@ curl -L
 curl -L 
   --request POST 
   --url 'https://api.emporix.io/configuration/{tenant}/configurations' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '[
     {
@@ -221,7 +221,7 @@ To update an existing tenant configuration, send a request to the [Updating a co
 curl -L 
   --request PUT 
   --url 'https://api.emporix.io/configuration/{tenant}/configurations/project_country' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '{
     "key": "project_country",
@@ -241,7 +241,7 @@ The `key` in the request body must match the `propertyKey` in the URL path. Also
 curl -L 
   --request PUT 
   --url 'https://api.emporix.io/configuration/{tenant}/configurations/customer.deletion.redirecturl' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '{
     "key": "customer.deletion.redirecturl",
@@ -257,7 +257,7 @@ curl -L
 curl -L 
   --request PUT 
   --url 'https://api.emporix.io/configuration/{tenant}/configurations/taxConfiguration' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '{
     "key": "taxConfiguration",
@@ -280,7 +280,7 @@ curl -L
 curl -L 
   --request PUT 
   --url 'https://api.emporix.io/configuration/{tenant}/configurations/packagingConf' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '{
     "key": "packagingConf",
@@ -308,7 +308,7 @@ curl -L
 curl -L 
   --request PUT 
   --url 'https://api.emporix.io/configuration/{tenant}/configurations/storefront.host' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '{
     "key": "storefront.host",
@@ -324,7 +324,7 @@ curl -L
 curl -L 
   --request PUT 
   --url 'https://api.emporix.io/configuration/{tenant}/configurations/cust.notification.email.from' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '{
     "key": "cust.notification.email.from",
@@ -348,7 +348,7 @@ To delete a tenant configuration, send a request to the [Deleting a configuratio
 curl -L 
   --request DELETE 
   --url 'https://api.emporix.io/configuration/{tenant}/configurations/{propertyKey}' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN'
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 ## Managing client configurations 
@@ -368,7 +368,7 @@ To retrieve a list of available clients for your tenant, send a request to the [
 ```bash
 curl -L 
   --url 'https://api.emporix.io/configuration/{tenant}/clients' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 
@@ -393,7 +393,7 @@ To retrieve all configurations for a specific client, send a request to the [Ret
 ```bash
 curl -L 
   --url 'https://api.emporix.io/configuration/{tenant}/clients/{client}/configurations' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 
@@ -402,7 +402,7 @@ curl -L
 ```bash
 curl -L 
   --url 'https://api.emporix.io/configuration/{tenant}/clients/saas-ag.caas-indexing-service-client/configurations' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 
@@ -433,7 +433,7 @@ You can also filter client configurations by specific keys using the `keys` quer
 ```bash
 curl -L 
   --url 'https://api.emporix.io/configuration/{tenant}/clients/{client}/configurations?keys=algolia_activation' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 
@@ -450,7 +450,7 @@ To retrieve a specific client configuration by its key, send a request to the [R
 ```bash
 curl -L 
   --url 'https://api.emporix.io/configuration/{tenant}/clients/{client}/configurations/{propertyKey}' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 
@@ -459,7 +459,7 @@ curl -L
 ```bash
 curl -L 
   --url 'https://api.emporix.io/configuration/{tenant}/clients/saas-ag.caas-indexing-service-client/configurations/indexing_configuration' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 
@@ -491,7 +491,7 @@ To create new client configurations, send a request to the [Creating client conf
 curl -L 
   --request POST 
   --url 'https://api.emporix.io/configuration/{tenant}/clients/{client}/configurations' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '[
     {
@@ -507,7 +507,7 @@ curl -L
 curl -L 
   --request POST 
   --url 'https://api.emporix.io/configuration/{tenant}/clients/client_one/configurations' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '[
     {
@@ -549,7 +549,7 @@ To update an existing client configuration, send a request to the [Updating a cl
 curl -L 
   --request PUT 
   --url 'https://api.emporix.io/configuration/{tenant}/clients/{client}/configurations/{propertyKey}' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '{
     "client": "example_client",
@@ -572,7 +572,7 @@ To delete a client configuration, send a request to the [Deleting a client confi
 curl -L 
   --request DELETE 
   --url 'https://api.emporix.io/configuration/{tenant}/clients/{client}/configurations/{propertyKey}' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN'
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 ## Retrieving global configurations
@@ -592,7 +592,7 @@ To retrieve a list of global configurations, send a request to the [Retrieving g
 ```bash
 curl -L 
   --url 'https://api.emporix.io/configuration/{tenant}/global-configurations' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 
@@ -601,7 +601,7 @@ You can also filter global configurations by specific keys using the `keys` quer
 ```bash
 curl -L 
   --url 'https://api.emporix.io/configuration/{tenant}/global-configurations?keys=project_lang,project_curr' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 

--- a/configuration/currency-service/currency.md
+++ b/configuration/currency-service/currency.md
@@ -107,7 +107,7 @@ You can also get a list of all the currencies for your tenant by sending a reque
 ```bash
 curl -L 
   --url 'https://api.emporix.io/currency/{tenant}/currencies' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 

--- a/configuration/unit-handling-service/unit-handling.md
+++ b/configuration/unit-handling-service/unit-handling.md
@@ -100,7 +100,7 @@ Before creating a price model with `unitCode: "kg"`, first verify if the unit ex
 ```bash
 curl -L 
   --url 'https://api.emporix.io/unit-handling/{tenant}/units' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 
@@ -110,7 +110,7 @@ If the unit exists, proceed with creating the price model:
 curl -L 
   --request POST 
   --url 'https://api.emporix.io/price/{tenant}/priceModels' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '{
     "includesTax": true,

--- a/delivery-and-shipping/shipping.md
+++ b/delivery-and-shipping/shipping.md
@@ -86,7 +86,7 @@ Shipping zones are countries that your business delivers products to. You can cr
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/shipping/{tenant}/{site}/zones' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: fr' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -113,7 +113,7 @@ You can set up shipping groups for customers and define different shipping metho
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/shipping/{tenant}/{site}/groups' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: fr' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -140,7 +140,7 @@ By adding customers to shipping groups, you can offer them different shipping me
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/shipping/{tenant}/{site}/cgrelations' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "customerId": "C001",
@@ -163,7 +163,7 @@ Add shipping methods and configure shipping fees by calling the [Creating a ship
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/shipping/{tenant}/{site}/zones/{zoneId}/methods' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: fr'
   -H 'Content-Type: application/json' 
   -d '{
@@ -228,7 +228,7 @@ Add delivery times by calling the [Creating a delivery time](https://developer.e
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/shipping/{tenant}/{site}/zones/{zoneId}/methods' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: fr'
   -H 'Content-Type: application/json' 
   -d '{
@@ -293,7 +293,7 @@ Add delivery time slots by calling the [Creating a delivery time slot](https://d
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/shipping/{tenant}/delivery-times/{deliveryTimeId}/slots?validateOverlap=true' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "shippingMethod": "method2",
@@ -343,7 +343,7 @@ Shipping times for particular postal codes are automatically calculated based on
 ```bash
 curl -i -X GET 
   'https://api.emporix.io/shipping/{tenant}/{site}/cgrelations/{customerId}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 {% endstep %}
 
@@ -357,7 +357,7 @@ Add the delivery information to the cart by calling the [Updating a cart](https:
 ```bash
 curl -i -X PUT 
   'https://api.emporix.io/cart/{tenant}/carts/{cartId}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "customerId": "87413250",

--- a/media/media/media.md
+++ b/media/media/media.md
@@ -45,7 +45,7 @@ If you want to upload the asset to the database, you need to send a multipart re
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/media/{tenant}/assets' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: multipart/form-data' 
   -F 'file=[object Object]' 
   -F 'body=[object Object]'
@@ -66,7 +66,7 @@ Check out the "Asset of the BLOB type added for a CATEGORY" example:
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/media/{tenant}/assets' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: multipart/form-data' 
   -F 'file=[object Object]' 
   -F 'body=[object Object]'

--- a/orders/availability/availability.md
+++ b/orders/availability/availability.md
@@ -54,7 +54,7 @@ To add availability-related information for a specific product, you need to send
 ```bash
 curl -i -X POST \
   'https://api.emporix.io/availability/{tenant}/availability/{productId}/{site}' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' \
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
   -H 'Content-Type: application/json' \
   -d '{
     "stockLevel": 10,
@@ -88,7 +88,7 @@ Example bulk request:
 ```bash
 curl -i -X POST \
   'https://api.emporix.io/availability/{tenant}/availability/bulk' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' \
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
   -H 'Content-Type: application/json' \
   -d '[
     {
@@ -125,7 +125,7 @@ You can also retrieve availability information for multiple products at once by 
 ```bash
 curl -i -X GET \
   'https://api.emporix.io/availability/{tenant}/availability/{productId}/{site}' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 ## How to calculate a product bundle's stock level
@@ -171,7 +171,7 @@ To find out what the stock level of a product bundle is, you need to send a requ
 ```bash
 curl -i -X GET \
   'https://api.emporix.io/availability/{tenant}/availability/{productId}/{site}' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 The response includes both the availability information of the bundle as a whole, as well as the bundled products.

--- a/orders/invoice/invoice.md
+++ b/orders/invoice/invoice.md
@@ -66,7 +66,7 @@ To set up the invoice configuration, call the [Creating new configurations](http
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/configuration/{tenant}/configurations' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "key": "invoiceSettings",
@@ -93,7 +93,7 @@ This configuration is used to set up the format of invoice numbers. Set up the n
 ```bash
 curl -i -X POST 
   https://api.emporix.io/sequential-id/sequenceSchemas 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "name": "invoiceNoSequence",

--- a/orders/order/order.md
+++ b/orders/order/order.md
@@ -1118,7 +1118,7 @@ curl 'https://api.emporix.io/customerlogin/auth/anonymous/login?tenant={tenant}&
 ```bash
 curl 'https://api.emporix.io/customer/{tenant}/login' 
   --request POST 
-  --header 'Authorization: Bearer {anonymous_access_token}' 
+  --header 'Authorization: Bearer {{ANONYMOUS_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '{
   "email": "customer@emporix.com",
@@ -1302,7 +1302,7 @@ curl 'https://api.emporix.io/order-v2/{tenant}/orders'
 curl --location --request PATCH 'https://api.emporix.io/order-v2/{tenant}/salesorders/{order_id}?recalculate=false' 
 --header 'Content-Type: application/json' 
 --header 'Accept: application/json' 
---header 'Authorization: Bearer {YOUR_OAUTH2_TOKEN}' 
+--header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
 --data '{
   "status": "SHIPPED"
   }'
@@ -1352,7 +1352,7 @@ Order Service APIs provide also tools for controlling the status transitions log
 ```bash
 curl -L 
   --url 'https://api.emporix.io/order-v2/{tenant}/salesorders/{orderId}/transitions' 
-  --header 'Authorization: Bearer {YOUR_OAUTH2_TOKEN}' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 

--- a/orders/returns/returns.md
+++ b/orders/returns/returns.md
@@ -219,7 +219,7 @@ In this scenario, the customer updates the reason for the return.
 ```bash
 curl -i -X PUT 
   'https://api.emporix.io/return/{tenant}/returns/{returnId}' 
-  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
+  -H 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -H 'saas-token: string' 
   -d '{

--- a/orders/returns/returns.md
+++ b/orders/returns/returns.md
@@ -28,7 +28,7 @@ In the following example, we are changing the expiration date offset to 14 days.
 ```bash
 curl -i -X PUT 
   'https://api.emporix.io/configuration/{tenant}/configurations/{propertyKey}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "key": "return.defaultExpiryDate",
@@ -81,7 +81,7 @@ The `returns.returns_read` and `returns.returns_manage` scopes are only required
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/return/{tenant}/returns' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -H 'saas-token: string' 
   -d '{
@@ -147,7 +147,7 @@ The `returns.returns_read_own` and `returns.returns_manage_own` scopes are only 
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/return/{tenant}/returns' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -H 'saas-token: string' 
   -d '{
@@ -219,7 +219,7 @@ In this scenario, the customer updates the reason for the return.
 ```bash
 curl -i -X PUT 
   'https://api.emporix.io/return/{tenant}/returns/{returnId}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -H 'saas-token: string' 
   -d '{
@@ -283,7 +283,7 @@ In this scenario, the employee updates the approval status of the return request
 ```bash
 curl -i -X PUT 
   'https://api.emporix.io/return/{tenant}/returns/{returnId}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -H 'saas-token: string' 
   -d '{

--- a/prices-and-taxes/price-service/price.md
+++ b/prices-and-taxes/price-service/price.md
@@ -55,7 +55,7 @@ To add a new entry to your configuration of currencies, you need to send a reque
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/currency/{tenant}/currencies' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: de' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -86,7 +86,7 @@ To create a new price model, you need to send a request to the [Creating a new p
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/price/{tenant}/priceModels' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -137,7 +137,7 @@ Price models that use the basic pricing strategy have one tier. To retrieve its 
 curl -i -X GET 
   'https://api.emporix.io/price/{tenant}/priceModels/{priceModelId}' 
   -H 'Accept-Language: string' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 The ID can be found in the `tierDefinition.tiers.id` field.
@@ -155,7 +155,7 @@ To define a new price for a product, you need to send a request to the [Creating
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/price/{tenant}/prices' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -492,7 +492,7 @@ Make sure to set a value for the `currency` field in the request body. Otherwise
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/price/{tenant}/price-lists' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -526,7 +526,7 @@ To create a new price list with a legal entity, send a request to the [Creating 
 curl -L 
   --request POST 
   --url 'https://api.emporix.io/price/{tenant}/price-lists' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '{
     "name": {
@@ -561,7 +561,7 @@ To create a new list-specific price, you need to send a request to the [Adding a
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/price/{tenant}/price-lists/{priceListId}/prices' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
   "itemId": {
@@ -657,7 +657,7 @@ Create a sample product through the [Creating a new product](https://developer.e
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/product/{tenant}/products?skipVariantGeneration=false&doIndex=true' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -737,7 +737,7 @@ Start with defining a price model with [Creating a price model](https://develope
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/price/{tenant}/priceModels' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -781,7 +781,7 @@ Now, retrieve the automatically-generated ID of the pricing tier, use the [Retri
 curl -i -X GET 
   'https://api.emporix.io/price/{tenant}/priceModels/{priceModelId}' 
   -H 'Accept-Language: string' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 Once you know the tier ID, define a price for the bananas, use the [Creating a new price](https://developer.emporix.io/api-references/api-guides/prices-and-taxes/price-service/api-reference/prices#post-price-tenant-prices) endpoint:
@@ -795,7 +795,7 @@ Once you know the tier ID, define a price for the bananas, use the [Creating a n
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/price/{tenant}/prices' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -828,7 +828,7 @@ Then, define a price model where the price per kilogram changes based on the ord
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/price/{tenant}/priceModels' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -876,7 +876,7 @@ Now, retrieve the automatically-generated IDs of the pricing tiers, use the [Ret
 curl -i -X GET 
   'https://api.emporix.io/price/{tenant}/priceModels/{priceModelId}' 
   -H 'Accept-Language: string' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 Once you know the tier IDs, define another price for the bananas, use the [Creating a new price](https://developer.emporix.io/api-references/api-guides/prices-and-taxes/price-service/api-reference/prices#post-price-tenant-prices) endpoint.
@@ -884,7 +884,7 @@ Once you know the tier IDs, define another price for the bananas, use the [Creat
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/price/{tenant}/prices' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -935,7 +935,7 @@ Check the best price for both one kilogram and ten kilograms of bananas:
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/price/{tenant}/match-prices' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "targetCurrency": "EUR",
@@ -1001,7 +1001,7 @@ Define sales tax rates for the desired country by sending a request to the [Crea
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/tax/{tenant}/taxes' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -1061,7 +1061,7 @@ To update a product with applicable tax classes, send a request to the [Partiall
 ```bash
 curl -i -X PATCH 
   'https://api.emporix.io/product/{tenant}/products/{productId}?skipVariantGeneration=false&doIndex=true' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -1087,7 +1087,7 @@ To calculate a gross price between countries, send a request to the [Matching pr
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/price/{tenant}/match-prices' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "targetCurrency": "EUR",
@@ -1135,7 +1135,7 @@ Add the currency in which the price will be retrieved to your configuration of c
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/currency/{tenant}/currencies' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: de' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -1169,7 +1169,7 @@ To define a new exchange rate, send a request to the [Creating a new exchange ra
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/currency/{tenant}/exchanges' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "sourceCurrency": "EUR",
@@ -1191,7 +1191,7 @@ To retrieve a price in the desired currency, send a request to the [Matching pri
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/price/{tenant}/match-prices' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "targetCurrency": "USD",
@@ -1245,7 +1245,7 @@ To add or update the `includesTax` field in your site's settings, you need to se
 ```bash
 curl -i -X PATCH 
   'https://api.emporix.io/site/{tenant}/sites/{siteCode}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
   "defaultLanguage": "en",

--- a/prices-and-taxes/tax-service/tax.md
+++ b/prices-and-taxes/tax-service/tax.md
@@ -49,7 +49,7 @@ Then, send a request to the [Calculating net and gross values for prices](https:
 ```bash
 curl -i -X PUT 
   'https://api.emporix.io/tax/{tenant}/taxes/calculation-commands' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "input": {
@@ -94,7 +94,7 @@ Then, send a request to the [Calculating net and gross values for prices](https:
 ```bash
 curl -i -X PUT 
   'https://api.emporix.io/tax/{tenant}/taxes/calculation-commands' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "input": {
@@ -161,7 +161,7 @@ Then, send a request to the [Calculating net and gross values for prices](https:
 ```bash
 curl -i -X PUT 
   'https://api.emporix.io/tax/{tenant}/taxes/calculation-commands' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "input": {

--- a/products-labels-and-brands/brand-service/brand.md
+++ b/products-labels-and-brands/brand-service/brand.md
@@ -60,7 +60,7 @@ To create a brand and add media files to it, you need to send a request to the [
 ```bash
 curl -i -X POST 
   https://api.emporix.io/brand/brands 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: en' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -129,7 +129,7 @@ To update the existing product with brand information, you need to send a reques
 ```bash
 curl -i -X PATCH 
   'https://api.emporix.io/product/{tenant}/products/{productId}?skipVariantGeneration=false&doIndex=true' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{

--- a/products-labels-and-brands/label-service/label.md
+++ b/products-labels-and-brands/label-service/label.md
@@ -30,7 +30,7 @@ To create a new label, send the request to the [Creating a label](https://develo
 ```bash
 curl -i -X POST 
   https://api.emporix.io/label/labels 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "name": "Worldwide Shipment",
@@ -92,7 +92,7 @@ To specify a brand for a product, you need to provide the `labelId` field on pro
 ```bash
 curl -i -X PATCH 
   'https://api.emporix.io/product/{tenant}/products/{productId}?skipVariantGeneration=false&doIndex=true' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{

--- a/products-labels-and-brands/product-service/product.md
+++ b/products-labels-and-brands/product-service/product.md
@@ -59,7 +59,7 @@ To define sales tax rates for a country, send a request to the [Creating a new t
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/tax/{tenant}/taxes' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -107,7 +107,7 @@ To add a single basic product, send a request to the [Creating a new product](ht
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/product/{tenant}/products' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "name": "Smartphone X2",
@@ -126,7 +126,7 @@ You can also add multiple basic products at the same time. To achieve that, send
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/product/{tenant}/products/bulk' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '[
     {
@@ -163,7 +163,7 @@ Sending a json/application request to the Creating an asset endpoint does **not*
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/media/{tenant}/assets' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: multipart/form-data' 
   -F 'file=[object Object]' 
   -F 'body=[object Object]'
@@ -184,7 +184,7 @@ To create a new product template, call the [Creating a new product template](htt
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/product/{tenant}/product-templates' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -234,7 +234,7 @@ To create a new product by applying a product template to it, call the [Creating
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/product/{tenant}/products' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "name": "Smartphone X2",
@@ -286,7 +286,7 @@ In this example, we create a bundle containing a T-shirt product and socks produ
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/product/{tenant}/products' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
   "name": "T-shirt and socks bundle",
@@ -341,7 +341,7 @@ The `product.product_update` scope is required. The `product.product_publish` an
 ```bash
 curl -i -X PUT 
   'https://api.emporix.io/product/{tenant}/products/bulk?skipVariantGeneration=false&doIndex=true' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -521,7 +521,7 @@ Call the [Creating a new product template](https://developer.emporix.io/api-refe
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/product/{tenant}/product-templates' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -594,7 +594,7 @@ To create a single `parent_variant` type of product with variants, send a reques
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/product/{tenant}/products?skipVariantGeneration=false&doIndex=true' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -638,7 +638,7 @@ If you want to create multiple `parent_variant` products at the same time, send 
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/product/{tenant}/products/bulk?skipVariantGeneration=false&doIndex=true' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '[
@@ -759,7 +759,7 @@ Each of the attributes has its own metadata element, where you can specify wheth
 ```bash
 curl -i -X PUT 
   'https://api.emporix.io/product/{tenant}/product-templates/{product-template-id}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -848,7 +848,7 @@ When creating or updating a product of the `PARENT_VARIANT` type, by default, pr
 ```bash
 curl -i -X PATCH 
   'https://api.emporix.io/product/{tenant}/products/{productId}?skipVariantGeneration=false&doIndex=true' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -911,7 +911,7 @@ In the following example, we override the following fields:
 ```bash
 curl -i -X PUT 
   'https://api.emporix.io/product/{tenant}/products/{productId}?partial=false&skipVariantGeneration=false&doIndex=true' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: string' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -997,7 +997,7 @@ To create the root product, call the [Creating a new product](https://developer.
 ```bash
 curl -i -X POST \
   'https://api.emporix.io/product/{tenant}/products' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' \
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
   -H 'Content-Type: application/json' \
   -d '{
     "id": "mobile-15-pro",
@@ -1035,7 +1035,7 @@ Each attribute value uses the `dynamicVariantAttribute` structure:
 ```bash
 curl -i -X POST \
   'https://api.emporix.io/product/{tenant}/products' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' \
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
   -H 'Content-Type: application/json' \
   -d '{
     "id": "mobile-15-pro-l1",
@@ -1089,7 +1089,7 @@ L2 variants are children of L1 variants. They declare only the attributes they i
 ```bash
 curl -i -X POST \
   'https://api.emporix.io/product/{tenant}/products' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' \
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
   -H 'Content-Type: application/json' \
   -d '{
     "id": "mobile-15-pro-l2-retail",
@@ -1124,7 +1124,7 @@ To retrieve the root product with its complete variant tree, call the [Retrievin
 ```bash
 curl -i -X GET \
   'https://api.emporix.io/product/{tenant}/products/mobile-15-pro' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 The response includes a `variants` map ready for your storefront:
@@ -1217,7 +1217,7 @@ To retrieve a child product, call the [Retrieving a product](https://developer.e
 ```bash
 curl -i -X GET \
   'https://api.emporix.io/product/{tenant}/products/mobile-15-pro-l2-retail' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 ```json
@@ -1266,7 +1266,7 @@ For a single product write, the `variants` map on all ancestor products is updat
 ```bash
 curl -i -X PUT \
   'https://api.emporix.io/product/{tenant}/products/mobile-15-pro-l1' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' \
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
   -H 'Content-Type: application/json' \
   -d '{
     "name": { "en": "Mobile Phone 15 Pro – 256 GB Blue", "de": "Mobile Phone 15 Pro – 256 GB Blau" },
@@ -1338,7 +1338,7 @@ To trigger recalculation, call the [Triggering dynamic variant recalculation](ht
 ```bash
 curl -i -X POST \
   'https://api.emporix.io/product/{tenant}/products/recalculate' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' \
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
   -H 'Content-Type: application/json' \
   -d '{
     "productIds": [
@@ -1404,7 +1404,7 @@ Use the job ID from the response and call the [Retrieving a recalculation job](h
 ```bash
 curl -i -X GET \
   'https://api.emporix.io/product/{tenant}/products/recalculate/jobs/job-a1b2c3d4-e5f6-7890-abcd-ef1234567890' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 A finished job:
@@ -1451,7 +1451,7 @@ To monitor the overall import progress, call the [Listing recalculation jobs](ht
 ```bash
 curl -i -X GET \
   'https://api.emporix.io/product/{tenant}/products/recalculate/jobs?status=PENDING' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 Available status filter values: `PENDING`, `PROCESSING`, `FINISHED`, `FAILED`, `FAILED_PERMANENT`.

--- a/quickstart/api-intro.md
+++ b/quickstart/api-intro.md
@@ -119,7 +119,7 @@ Send a sample request. For example, create a basic product:
 curl -L \
   --request POST \
   --url 'https://api.emporix.io/product/{tenant}/products' \
-  --header 'Authorization: Bearer {{YOUR_OAUTH2_TOKEN}}' \
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
   --header 'Content-Type: application/json' \
   --data '{
     "name": "Smartphone X2",

--- a/quickstart/initial-tenant-checkout-config.md
+++ b/quickstart/initial-tenant-checkout-config.md
@@ -1027,7 +1027,7 @@ To display the order details to the customer on the storefront, use the [Retriev
 ```bash
 curl -L \
   --url 'https://api.emporix.io/order-v2/{{tenant}}/orders/{{orderId}}' \
-  --header 'Authorization: Bearer <CUSTOMER_ACCESS_TOKEN>' \
+  --header 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}' \
   --header 'saas-token: text' \
   --header 'Accept: */*'
 ```
@@ -1036,7 +1036,7 @@ To obtain the order details and later send tem to the ERP/CRM system, use the [R
 ```bash
 curl -L \
   --url 'https://api.emporix.io/order-v2/{{tenant}}/salesorders/{{orderId}}' \
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' \
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
   --header 'Accept: */*'
 ```
 

--- a/quotes/quote/quote.md
+++ b/quotes/quote/quote.md
@@ -149,7 +149,7 @@ If you need custom quote status change reasons, create them by sending a request
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/quote/{tenant}/quote-reasons' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: de' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -192,7 +192,7 @@ The following scope is required:
 ```bash
 curl -i -X GET 
   'https://api.emporix.io/site/{tenant}/sites/{siteCode}/mixins' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 {% endstep %}
 
@@ -210,7 +210,7 @@ The following scope is required:
 ```bash
 curl -i -X PATCH 
   'https://api.emporix.io/site/{tenant}/sites/{siteCode}/mixins/{mixinName}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "active": true
@@ -228,7 +228,7 @@ You can create new quote status change reasons, by sending a request to the [Cre
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/quote/{tenant}/quote-reasons' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: de' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -276,7 +276,7 @@ The customer can place a quote request on the storefront only if they have creat
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/quote/{tenant}/quotes' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "cartId": "4472v8d2309b06d46d3cf19fe",
@@ -312,7 +312,7 @@ The following scope is required:
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/quote/{tenant}/quotes' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "customerId": "9tt954309b06d46d3cf19fe",
@@ -390,7 +390,7 @@ In this example, an employee updates multiple fields:
 curl -L 
   --request PATCH 
   --url 'https://api.emporix.io/quote/{tenant}/quotes/{quoteId}' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '[
     {
@@ -459,7 +459,7 @@ In the following example, an employee updates only the price of requested item:
 curl -L 
   --request PATCH 
   --url 'https://api.emporix.io/quote/{tenant}/quotes/{quoteId}' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '[
     {
@@ -485,7 +485,7 @@ The following scope is required:
 ```bash
 curl -i -X PATCH 
   'https://api.emporix.io/quote/{tenant}/quotes/{quoteId}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "op": "replace",
@@ -511,7 +511,7 @@ The following scope is required:
 
 curl -i -X PATCH 
   'https://api.emporix.io/quote/{tenant}/quotes/{quoteId}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "op": "replace",
@@ -540,7 +540,7 @@ In this example, a customer receives a quote and decides to decline it because t
 ```bash
 curl -i -X PATCH 
   'https://api.emporix.io/quote/{tenant}/quotes/{quoteId}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "op": "replace",
@@ -649,7 +649,7 @@ To generate a quote pdf, send a request to the [Creating a quote PDF](https://de
 curl -L 
   --request POST 
   --url 'https://api.emporix.io/quote/{tenant}/quotes/{quoteId}/pdf' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
  

--- a/rewards-and-promotions/coupon/coupon.md
+++ b/rewards-and-promotions/coupon/coupon.md
@@ -32,7 +32,7 @@ When creating a free shipping coupon, ensure that the `categoryRestricted` param
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/coupon/{tenant}/coupons' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
   "code": "ENG2OC0",
@@ -68,7 +68,7 @@ To limit a coupon to a specific customer, you need to provide the customer ID in
 ```bash
 curl -i -X POST 
  'https://api.emporix.io/coupon/{tenant}/coupons' 
- -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+ -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
  -H 'Content-Type: application/json' 
  -d '{
    "code": "ENG2OC0",
@@ -106,7 +106,7 @@ To limit a coupon to a specific category, you need to set the `categoryRestricte
 ```bash
 curl -i -X POST 
  'https://api.emporix.io/coupon/{tenant}/coupons' 
- -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+ -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
  -H 'Content-Type: application/json' 
  -d '{
    "code": "ENG2OC0",
@@ -152,7 +152,7 @@ To update an existing coupon, you need to send a request to the [Partially updat
 ```bash
 curl -i -X PATCH 
   'https://api.emporix.io/coupon/{tenant}/coupons/{code}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "name": "Winter Sale 2022",
@@ -202,7 +202,7 @@ In the following example, we are changing the maximum number of coupons that can
 ```bash
 curl -i -X PUT 
   'https://api.emporix.io/configuration/{tenant}/configurations/{propertyKey}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "key": "maxNumberOfCouponsPerCart",
@@ -229,7 +229,7 @@ If you want to apply more than one coupon to a cart, you need to send a separate
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/cart/{tenant}/carts/{cartId}/discounts' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "code": "CVMTRE"
@@ -262,7 +262,7 @@ Redeem a coupon on behalf of a customer by sending a request to the [Redeeming t
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/coupon/{tenant}/coupons/{code}/redemptions' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "customerNumber": "CustomerId",
@@ -298,7 +298,7 @@ First, check if your `couponSettings` mixin has already been configured by sendi
 ```bash
 curl -i -X GET 
   'https://api.emporix.io/site/{tenant}/sites/{siteCode}/mixins/{mixinName}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 If your site's `couponSettings` have never been configured before or have been deleted, you will receive a `404` error in the response body.
@@ -314,7 +314,7 @@ In this case, to configure referral coupons, you need to send a request to the [
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/site/{tenant}/sites/{siteCode}/mixins' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "testMixin": {
@@ -352,7 +352,7 @@ In this case, to configure referral coupons, you need to send a request to the [
 ```bash
 curl -i -X PATCH 
   'https://api.emporix.io/site/{tenant}/sites/{siteCode}/mixins/{mixinName}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "active": true
@@ -374,7 +374,7 @@ First, check if your `emailTemplates` have already been configured by sending a 
 ```bash
 curl -i -X GET 
   'https://api.emporix.io/configuration/{tenant}/configurations/{propertyKey}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 If your `emailTemplates` have never been configured before or have been deleted, you will receive a `404` error in the response body.
@@ -390,7 +390,7 @@ In this case, to configure referral email templates, you need to send a request 
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/configuration/{tenant}/configurations' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
   "key": "emailTemplates",
@@ -455,7 +455,7 @@ To add referral email templates to an existing `emailTemplates` configuration, y
 ```bash
 curl -i -X PUT 
   'https://api.emporix.io/configuration/{tenant}/configurations/{propertyKey}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "key": "emailTemplates",
@@ -502,7 +502,7 @@ To manually generate a referral coupon for a specific customer, you need to send
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/coupon/{tenant}/referral-coupons/{customerNumber}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 ## How to retrieve a specific customer's referral coupon

--- a/rewards-and-promotions/reward-points/reward-points.md
+++ b/rewards-and-promotions/reward-points/reward-points.md
@@ -30,7 +30,7 @@ The following scope is required: `site.site_manage`.
 ```bash
 curl -i -X GET 
   'https://api.emporix.io/site/{tenant}/sites/{siteCode}/mixins' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 ### Update the reward points settings for a site
@@ -61,7 +61,7 @@ The following scope is required: `site.site_manage`.
 ```bash
 curl -i -X PATCH 
   'https://api.emporix.io/site/{tenant}/sites/{siteCode}/mixins/{mixinName}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "active": true
@@ -93,7 +93,7 @@ The following scope is required: `rewardspoints.rewardpoints_manage`.
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/reward-points/customer/{customerId}/addPoints?siteCode=main' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "id": "12345fee-0b83-48aa-95dc-11e3dcf84aaa",
@@ -124,7 +124,7 @@ To achieve that, you must send a request to the [Creating redemption options](ht
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/reward-points/{tenant}/redeemOptions' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "type": "coupon",
@@ -163,7 +163,7 @@ If the customer wants to redeem reward points in exchange for a coupon, first th
 ```bash
 curl -i -X GET 
   'https://api.emporix.io/reward-points/{tenant}/redeemOptions' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 ### Redeem reward points for a coupon code
@@ -183,7 +183,7 @@ Reward points can only be exchanged for percentage and absolute coupons.
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/reward-points/public/customer/redeem?siteCode=main' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "id": "575937654bf757001d8496c9"
@@ -209,6 +209,6 @@ To check the reward points balance and history, the customer sends a request to 
 ```bash
 curl -i -X GET 
   https://api.emporix.io/reward-points/public/customer/summary 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
  

--- a/rewards-and-promotions/reward-points/reward-points.md
+++ b/rewards-and-promotions/reward-points/reward-points.md
@@ -163,7 +163,7 @@ If the customer wants to redeem reward points in exchange for a coupon, first th
 ```bash
 curl -i -X GET 
   'https://api.emporix.io/reward-points/{tenant}/redeemOptions' 
-  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
+  -H 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}'
 ```
 
 ### Redeem reward points for a coupon code
@@ -183,7 +183,7 @@ Reward points can only be exchanged for percentage and absolute coupons.
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/reward-points/public/customer/redeem?siteCode=main' 
-  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
+  -H 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "id": "575937654bf757001d8496c9"
@@ -209,6 +209,6 @@ To check the reward points balance and history, the customer sends a request to 
 ```bash
 curl -i -X GET 
   https://api.emporix.io/reward-points/public/customer/summary 
-  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
+  -H 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}'
 ```
  

--- a/standard-practices/mixins.md
+++ b/standard-practices/mixins.md
@@ -146,7 +146,7 @@ The procedure below presents applying mixins to a `Customer` object.
 ```bash
 curl -i -X PATCH \
   'https://api.emporix.io/customer/{tenant}/customers/{customerNumber}' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' \
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
   -H 'Content-Type: application/json' \
   -d '{
     "contactEmail": "example@customer.com",

--- a/standard-practices/translations.md
+++ b/standard-practices/translations.md
@@ -45,7 +45,7 @@ Here's an example on how to create a measurement unit with its name in German:
 ```bash
 curl -i -X POST \
   'https://api.emporix.io/unit-handling/{tenant}/units' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' \
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
   -H 'Content-Language: de' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -71,7 +71,7 @@ Here's an example on how to create a measurement unit with its name in multiple 
 ```bash
 curl -i -X POST \
   'https://api.emporix.io/unit-handling/{tenant}/units' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' \
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
   -H 'Content-Language: *' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -94,7 +94,7 @@ Here's an example on how to retrieve a product's localized fields in German:
 curl -i -X GET \
   'https://api.emporix.io/product/{tenant}/products/{productId}?fields=name%2Ccode&expand=string&rawValue=true' \
   -H 'Accept-Language: de' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 ## How to retrieve a localized object in all available languages
@@ -107,7 +107,7 @@ Here's an example on how to retrieve a product's localized fields in all availab
 curl -i -X GET \
   'https://api.emporix.io/product/{tenant}/products/{productId}?fields=name%2Ccode&expand=string&rawValue=true' \
   -H 'Accept-Language: *' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 ## How to add localized fields to an existing object
@@ -123,7 +123,7 @@ Here's an example on how to add translations to a measurement unit's name:
 ```bash
 curl -i -X PUT \
   'https://api.emporix.io/unit-handling/{tenant}/units/{unitCode}' \
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' \
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
   -H 'Content-Language: fr' \
   -H 'Content-Type: application/json' \
   -d '{

--- a/users-and-permissions/iam/iam.md
+++ b/users-and-permissions/iam/iam.md
@@ -46,7 +46,7 @@ To assign specific access control level to a group, first you need to retrieve a
 curl -i -X GET 
   'https://api.emporix.io/iam/{tenant}/access-controls?pageNumber=1&pageSize=60&metadataModifiedAt=2022-01-01&roleId=1rl5e52e-6e27-4ac5-9471-2467d3fb7503&resourceId=string&expand=role%2Cresource' 
   -H 'Accept-Language: string' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'X-Total-Count: true'
 ```
 
@@ -67,7 +67,7 @@ The user type in the `userType` parameter can be specified as `CUSTOMER` or `EMP
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/iam/{tenant}/groups' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Language: de' 
   -H 'Content-Type: application/json' 
   -d '{
@@ -110,7 +110,7 @@ The user type in the `userType` parameter can be specified as `customer` or `emp
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/iam/{tenant}/groups/{groupId}/users' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "userId": " ",

--- a/users-and-permissions/session-context/session-context.md
+++ b/users-and-permissions/session-context/session-context.md
@@ -123,7 +123,7 @@ When retrieving the session-context details, you must supply the `sessionId`. It
 ```bash
 curl -L \
   --url 'https://api.emporix.io/session-context/{tenant}/me/context' \
-  --header 'Authorization: Bearer YOUR_SECRET_TOKEN' \
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
   --header 'Accept: */*'
 ```
 
@@ -156,7 +156,7 @@ Retrieve the session context by sending a request to the [Retrieving a session c
 ```bash
 curl -i -X GET 
   'https://api.emporix.io/session-context/{tenant}/context/01736216-39a9-4801-b6f0-90a977453b75' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 The response is:
@@ -219,7 +219,7 @@ In the following example, we add an attribute by sending a request to the [Addin
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/session-context/{tenant}/context/{sessionId}/attributes' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "key": "additional attribute name",

--- a/users-and-permissions/session-context/session-context.md
+++ b/users-and-permissions/session-context/session-context.md
@@ -123,7 +123,7 @@ When retrieving the session-context details, you must supply the `sessionId`. It
 ```bash
 curl -L \
   --url 'https://api.emporix.io/session-context/{tenant}/me/context' \
-  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
+  --header 'Authorization: Bearer {{CUSTOMER_ACCESS_TOKEN}}' \
   --header 'Accept: */*'
 ```
 

--- a/utilities/schema/schema.md
+++ b/utilities/schema/schema.md
@@ -36,7 +36,7 @@ To extend the product entity in Management Dashboard with some industry-specific
 curl -L 
   --request POST 
   --url 'https://api.emporix.io/schema/{tenant}/schemas' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: application/json' 
   --data '{
     "name": {
@@ -118,7 +118,7 @@ Retrieve the created schema to get the schema URL by calling the [Retrieving a s
 ```bash
 curl -L 
   --url 'https://api.emporix.io/schema/{tenant}/schemas/{id}' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Accept: */*'
 ```
 
@@ -418,7 +418,7 @@ CURL request example:
 curl -L 
   --request POST 
   --url 'https://api.emporix.io/schema/{tenant}/references' 
-  --header 'Authorization: Bearer YOUR_OAUTH2_TOKEN' 
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   --header 'Content-Type: multipart/form-data' 
   --form 'file=[object Object]' 
   --form 'body=[object Object]'

--- a/utilities/sequential-id/sequentialid.md
+++ b/utilities/sequential-id/sequentialid.md
@@ -38,7 +38,7 @@ To create a schema for sequential IDs creation, send the request to the [Creatin
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/sequential-id/{tenant}/schemas' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "name": "testSchema",
@@ -79,7 +79,7 @@ To get the created schema details, make a call to the [Retrieving a schema](http
 ```bash
 curl -i -X GET 
   'https://api.emporix.io/sequential-id/{tenant}/schemas/{schemaId}' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 Copy the schema ID.
@@ -97,7 +97,7 @@ Activate the schema to apply it in the system so that the order numbers follow t
 ```bash
 curl -i -X POST 
   'https://api.emporix.io/sequential-id/{tenant}/schemas/{schemaId}/setActive' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 Provide the `sequenceSchemaID` in the request.
@@ -143,7 +143,7 @@ You can define vendor-specific, separate number ranges with consecutive numberin
 ```bash
 curl -i -X POST 
   https://api.emporix.io/sequential-id/sequenceSchemas 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "name": "invoiceNoSequence",

--- a/webhooks/webhook-service/webhooks-tutorial.md
+++ b/webhooks/webhook-service/webhooks-tutorial.md
@@ -53,7 +53,7 @@ If there is no prior subscription to the event of your choice, the `metadata.ver
 curl -i -X GET 
   'https://api.emporix.io/webhook/{tenant}/event-subscriptions' 
   -H 'Accept-Language: fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 ### Subscribe to events
@@ -73,7 +73,7 @@ In this example, you will subscribe to the following events: `catalog.created` a
 ```bash
 curl -i -X PATCH 
   'https://api.emporix.io/webhook/{tenant}/event-subscriptions' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>' 
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' 
   -H 'Content-Type: application/json' 
   -d '{
     "eventType": "catalog.created",
@@ -134,7 +134,7 @@ To generate the login link with the authentication token needed to connect a ten
 ```bash
 curl -i -X GET 
   'https://api.emporix.io/webhook/{tenant}/dashboard-access' 
-  -H 'Authorization: Bearer <YOUR_TOKEN_HERE>'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
 ```
 
 {% hint style="warning" %}


### PR DESCRIPTION
Purpose:
Standardize the use of authorization token placeholders across all documentation and API reference files.

What was changed:

Updated all code blocks, curl examples, YAML, and inline text referencing API tokens to a consistent variable format.
Replaced legacy and inconsistent placeholders (such as <YOUR_TOKEN_HERE>, <ACCESS_TOKEN>, {customer_access_token}) with modern, handlebars-style variables:
{{OAUTH2_ACCESS_TOKEN}}, {{CUSTOMER_ACCESS_TOKEN}}, or {{ANONYMOUS_ACCESS_TOKEN}} as appropriate.
Why:

Improves clarity and consistency for users integrating with Emporix APIs.
Reduces copy-paste errors and confusion over available token variable types.
Ensures all documentation presents a modern, professional, and consistent example style.
Scope:

40 files changed, spanning business logic, checkout, authentication, customer, brand, order, and configuration documentation.
Only documentation and code example files were modified.
No impact on run-time or business logic.
How to review:

Check that all token references in each affected file now follow the correct {{TOKEN_TYPE}} style.
No functional testing required; documentation only.