### PR TITLE
COP-5225: Remove unnecessary trait for PUT /cart/:id/batchItems

### DIFF
--- a/checkout/cart/api-reference/api.yml
+++ b/checkout/cart/api-reference/api.yml
@@ -2770,8 +2770,6 @@ paths:
         - OAuth2:   
             - cart.cart_manage
         - CustomerAccessToken: []
-      parameters:
-        - $ref: '#/components/parameters/trait_tenant'
       summary: Updating multiple products in cart
       tags:
         - Cart items

--- a/checkout/cart/api-reference/api.yml
+++ b/checkout/cart/api-reference/api.yml
@@ -2773,9 +2773,9 @@ paths:
       summary: Updating multiple products in cart
       tags:
         - Cart items
-    parameters:
-      - $ref: '#/components/parameters/cartId'
-      - $ref: '#/components/parameters/trait_tenant'
+      parameters:
+        - $ref: '#/components/parameters/cartId'
+        - $ref: '#/components/parameters/trait_tenant'
   '/cart/{tenant}/carts/{cartId}/items':
     get:
       responses:


### PR DESCRIPTION
PR just to test triggering gitbook checks. PUT is not visible in docs...

Result:
<img width="1012" height="371" alt="image" src="https://github.com/user-attachments/assets/105e2638-9e90-4b12-aef9-63c0eb0a2033" />
