### PR TITLE
docs: API reference updates — [BE] Allow for numbers in custom entity ids

### DIFF
--- a/users-and-permissions/iam/api-reference/api.yml
+++ b/users-and-permissions/iam/api-reference/api.yml
@@ -4920,7 +4920,7 @@ components:
       in: path
       required: true
       description: |
-        Unique identifier of a scope. Only letters, periods (`.`), hyphens (`-`), and underscores (`_`) are allowed.
+        Unique identifier of a scope. Only letters, digits, periods (`.`), hyphens (`-`), and underscores (`_`) are allowed.
       schema:
         type: string
         example: custom.scope

--- a/utilities/schema/api-reference/api.yml
+++ b/utilities/schema/api-reference/api.yml
@@ -2230,7 +2230,7 @@ components:
       properties:
         id:
           type: string
-          description: Unique code for the custom type. Can only contain uppercase letters and underscores.
+          description: Unique code for the custom type. Can contain uppercase letters, digits, and underscores. The first character must be a letter.
         name:
           type: object
           description: Localized custom type name in a form of a map of translations.


### PR DESCRIPTION
Auto-generated by **Emporix AI Buddy** for feature `ced830cc-5bcf-46e8-81e0-256a53a5d029` (COP-5844).

## Changed files

- `utilities/schema/api-reference/api.yml`
- `users-and-permissions/iam/api-reference/api.yml`

## Review summary

2 of 2 reviewed API reference files are approved. The changes are consistent across Schema and IAM documentation and correctly describe the broadened identifier rules: digits are now allowed in custom entity IDs and custom scope IDs. No issue patterns were found in the reviewed files; both updates are narrowly scoped, aligned with the spec diffs, and preserve unrelated content. Based on the reviewed API reference files, the batch adequately covers the public contract change for this feature, though changelog coverage was not part of these per-file approvals.

> ⚠️ Review all changes carefully before merging. The AI proposal may need manual adjustments.