### PR TITLE
docs: API reference updates — [Quote] add new fields to the Quote model

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -23,6 +23,33 @@ layout:
 # 2026
 
 {% updates format="full" %}
+{% update date="RELEASE_DATE" tags="new-feature" %}
+## Quote Service - customerReference and customerComment properties
+
+#### Overview
+
+The `Quote` object has been extended with two new properties that allow customers to provide additional information on their quotes:
+
+- `customerReference` - A customer-provided reference stored on the quote (e.g., a purchase order number like "PO-12345")
+- `customerComment` - A customer-provided comment stored on the quote (e.g., "Please deliver before Friday")
+
+These properties can be set when creating a quote, creating a quote from a cart, or when updating a quote.
+
+#### Updated endpoints
+
+| Endpoint                                                                                                                                                            | Description                                                                                                   |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| [Creating a quote](https://developer.emporix.io/api-references/api-guides/quotes/quote/api-reference/quote-management#post-quote-tenant-quotes)                     | Properties `customerReference` and `customerComment` can be provided.                                         |
+| [Creating a quote from a cart](https://developer.emporix.io/api-references/api-guides/quotes/quote/api-reference/quote-management#post-quote-tenant-quotes-from-cart) | Properties `customerReference` and `customerComment` can be provided.                                         |
+| [Retrieving quotes](https://developer.emporix.io/api-references/api-guides/quotes/quote/api-reference/quote-management#get-quote-tenant-quotes)                     | Properties `customerReference` and `customerComment` are returned.                                            |
+| [Retrieving a single quote](https://developer.emporix.io/api-references/api-guides/quotes/quote/api-reference/quote-management#get-quote-tenant-quotes-quoteid)     | Properties `customerReference` and `customerComment` are returned.                                            |
+| [Partially updating a quote](https://developer.emporix.io/api-references/api-guides/quotes/quote/api-reference/quote-management#patch-quote-tenant-quotes-quoteid)  | Properties `customerReference` and `customerComment` can be updated. Customers can update these on own quotes. |
+
+#### Known problems
+
+There are no known problems.
+{% endupdate %}
+
 {% update date="2026-07-06" tags="new-feature" %}
 ## AI Service - streaming chat responses
 

--- a/quotes/quote/api-reference/api.yaml
+++ b/quotes/quote/api-reference/api.yaml
@@ -1684,15 +1684,6 @@ components:
               format: date-time
               description: The Quote Reason modification timestamp.
     QuoteResponse:
-      properties:
-        customerReference:
-          type: string
-          description: Customer-provided reference stored on the quote.
-          example: PO-12345
-        customerComment:
-          type: string
-          description: Customer-provided comment stored on the quote.
-          example: Please deliver before Friday
       type: object
       properties:
         id:
@@ -1708,6 +1699,14 @@ components:
           enum:
             - B2B
             - B2C
+        customerReference:
+          type: string
+          description: Customer-provided reference stored on the quote.
+          example: PO-12345
+        customerComment:
+          type: string
+          description: Customer-provided comment stored on the quote.
+          example: Please deliver before Friday
         customer:
           type: object
           description: This attribute contains details about the customer for whom the quote was created.
@@ -2401,15 +2400,6 @@ components:
             type: string
             description: Modification date.
     QuoteCreateFromCartRequest:
-      properties:
-        customerReference:
-          type: string
-          description: Customer-provided reference stored on the quote.
-          example: PO-12345
-        customerComment:
-          type: string
-          description: Customer-provided comment stored on the quote.
-          example: Please deliver before Friday
       type: object
       description: This schema includes the attributes that are required to be provided when creating a quote from the cart.
       title: QuoteCreateFromCartRequest
@@ -2430,6 +2420,14 @@ components:
           description: For B2B customers, it represents the location which should specify the shipping address. For B2C customers, it represents identifier of customer's shipping address.
         shipping:
           $ref: '#/components/schemas/QuoteShipping'
+        customerReference:
+          type: string
+          description: Customer-provided reference stored on the quote.
+          example: PO-12345
+        customerComment:
+          type: string
+          description: Customer-provided comment stored on the quote.
+          example: Please deliver before Friday
   securitySchemes:
     OAuth2:
       type: oauth2

--- a/quotes/quote/api-reference/api.yaml
+++ b/quotes/quote/api-reference/api.yaml
@@ -113,6 +113,8 @@ paths:
                         shippingTaxCode: STANDARD
                       comment:
                         employeeComment: Employee comment
+                      customerReference: PO-12345
+                      customerComment: Please deliver before Friday
                       billingAddress:
                         id: 63440460cee2826d794fcb8a
                         name: ABC
@@ -330,6 +332,8 @@ paths:
                   cartId: 4472v8d2309b06d46d3cf19fe
                   billingAddressId: 4472v8d2309b06d46d3cf19dd
                   shippingAddressId: 4472v8d2309b06d46d3cf19dd
+                  customerReference: PO-12345
+                  customerComment: Please deliver before Friday
                   shipping:
                     value: 10
                     methodId: fedex-2dayground
@@ -669,6 +673,8 @@ paths:
                       validTo: '2023-03-25T09:36:55.974Z'
                     comment:
                       employeeComment: Employee comment
+                    customerReference: PO-12345
+                    customerComment: Please deliver before Friday
                     validTo: '2023-03-25T09:36:55.974Z'
                     totalPrice:
                       netValue: 205
@@ -852,7 +858,9 @@ paths:
         ### **Additional scope information**
         One of the scopes is required.
 
-        * The `quote.quote_manage_own` scope allows customers to modify only their own quotes by modifying the status to either `ACCEPTED` or `DECLINED`.
+        * The `quote.quote_manage_own` scope allows customers to modify only their own quotes.
+        * Customers can update the `status`, `customerReference`, and `customerComment` fields.
+        * Customer status updates are limited to `ACCEPTED`, `DECLINED`, and `IN_PROGRESS`.
 
         ***
       responses:
@@ -1069,6 +1077,18 @@ paths:
                       value: DECLINED
                       comment: new comment
                       quoteReasonId: 6437ed5dc0dc2925289a5bbd
+              Change customer reference:
+                value:
+                  - op: REPLACE
+                    path: /customerReference
+                    value:
+                      value: PO-12345
+              Change customer comment:
+                value:
+                  - op: REPLACE
+                    path: /customerComment
+                    value:
+                      value: Please deliver before Friday
               Accept quote:
                 value:
                   - op: REPLACE
@@ -1664,6 +1684,15 @@ components:
               format: date-time
               description: The Quote Reason modification timestamp.
     QuoteResponse:
+      properties:
+        customerReference:
+          type: string
+          description: Customer-provided reference stored on the quote.
+          example: PO-12345
+        customerComment:
+          type: string
+          description: Customer-provided comment stored on the quote.
+          example: Please deliver before Friday
       type: object
       properties:
         id:
@@ -2372,6 +2401,15 @@ components:
             type: string
             description: Modification date.
     QuoteCreateFromCartRequest:
+      properties:
+        customerReference:
+          type: string
+          description: Customer-provided reference stored on the quote.
+          example: PO-12345
+        customerComment:
+          type: string
+          description: Customer-provided comment stored on the quote.
+          example: Please deliver before Friday
       type: object
       description: This schema includes the attributes that are required to be provided when creating a quote from the cart.
       title: QuoteCreateFromCartRequest

--- a/quotes/quote/quote.md
+++ b/quotes/quote/quote.md
@@ -472,37 +472,6 @@ curl -L \
   ]'
 ```
 
-Employees can also update the customer-specific quote fields by using the `REPLACE` operation on the following paths:
-
-* `/customerReference`
-* `/customerComment`
-
-Example:
-
-```bash
-curl -L \
-  --request PATCH \
-  --url 'https://api.emporix.io/quote/{tenant}/quotes/{quoteId}' \
-  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
-  --header 'Content-Type: application/json' \
-  --data '[
-    {
-      "op": "REPLACE",
-      "path": "/customerReference",
-      "value": {
-        "value": "REF-EMP-001"
-      }
-    },
-    {
-      "op": "REPLACE",
-      "path": "/customerComment",
-      "value": {
-        "value": "Updated by employee"
-      }
-    }
-  ]'
-```
-
 ### Approving a quote by an employee
 
 When an employee accepts a quote, they approve it to be sent to the customer. Depending on the flow, the quote status changes from 'AWAITING', 'CREATING' or "IN\_PROGRESS" to 'OPEN"'.

--- a/quotes/quote/quote.md
+++ b/quotes/quote/quote.md
@@ -472,6 +472,37 @@ curl -L \
   ]'
 ```
 
+Employees can also update the customer-specific quote fields by using the `REPLACE` operation on the following paths:
+
+* `/customerReference`
+* `/customerComment`
+
+Example:
+
+```bash
+curl -L \
+  --request PATCH \
+  --url 'https://api.emporix.io/quote/{tenant}/quotes/{quoteId}' \
+  --header 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}' \
+  --header 'Content-Type: application/json' \
+  --data '[
+    {
+      "op": "REPLACE",
+      "path": "/customerReference",
+      "value": {
+        "value": "REF-EMP-001"
+      }
+    },
+    {
+      "op": "REPLACE",
+      "path": "/customerComment",
+      "value": {
+        "value": "Updated by employee"
+      }
+    }
+  ]'
+```
+
 ### Approving a quote by an employee
 
 When an employee accepts a quote, they approve it to be sent to the customer. Depending on the flow, the quote status changes from 'AWAITING', 'CREATING' or "IN\_PROGRESS" to 'OPEN"'.


### PR DESCRIPTION
Auto-generated by **Emporix AI Buddy** for feature `0769e82c-e1fd-45c7-8ed9-6fc8cb9a48a4` (COP-5874).

## Changed files

- `quotes/quote/api-reference/api.yaml`
- `quotes/quote/quote.md`

## Review summary

0 of 2 files are approved; both updates still need revision. The main issue pattern is incomplete contract coverage: the OpenAPI file documents examples and behavior notes but does not yet update the actual request/response schemas for `customerReference` and `customerComment`, and the PATCH guidance should use the explicit allowed customer status values from the feature. In the Markdown guide, the documented customer-facing additions are consistent with the feature, but one anchor failure left the employee PATCH support undocumented. Cross-file consistency is only partial right now, because both files acknowledge the new fields but neither fully covers all affected create/read/patch contract surfaces. As a result, the batch does not yet adequately cover the feature and needs a follow-up pass to complete the schema and PATCH documentation. After the revision round, 0 file(s) approved, 2 still flagged.

> ⚠️ Review all changes carefully before merging. The AI proposal may need manual adjustments.