### PR TITLE
docs: API reference updates — 1. Add `GROUP` as assignment type to customer segments

### DIFF
--- a/companies-and-customers/customer-segments/api-reference/README.md
+++ b/companies-and-customers/customer-segments/api-reference/README.md
@@ -6,4 +6,163 @@ icon: rectangle-terminal
 
 # API Reference
 
- 
+## Group assignments for customer segments
+
+{% hint style="warning" %}
+Preview
+{% endhint %}
+
+Customer segments now support the `GROUP` assignment type. You can assign IAM customer groups to a customer segment. Only groups with `userType` set to `CUSTOMER` can be assigned.
+
+### Upsert a group assignment
+
+`PUT /{tenant}/segments/{segmentId}/groups/{groupId}`
+
+Creates or updates a group assignment for the specified segment.
+
+**Required scope:** `segment.segment_manage`
+
+#### Path parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `tenant` | string | Tenant name. |
+| `segmentId` | string | Segment identifier. |
+| `groupId` | string | IAM group identifier. |
+
+#### Request body
+
+Uses the same assignment payload as other segment assignment upsert endpoints.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `mixins` | object | Optional assignment mixins. |
+| `metadata` | object | Assignment metadata. |
+
+#### Responses
+
+| Status | Description |
+| --- | --- |
+| `201 Created` | The assignment is created and the response returns a creation response body. |
+| `204 No Content` | The assignment is updated. |
+| `400 Bad Request` | The segment does not exist or the group `userType` is not `CUSTOMER`. |
+| `404 Not Found` | The group does not exist. |
+| `403 Forbidden` | The caller does not have the required scope. |
+
+### Get a group assignment
+
+`GET /{tenant}/segments/{segmentId}/groups/{groupId}`
+
+Returns a single group assignment.
+
+**Required scope:** `segment.segment_read`
+
+#### Path parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `tenant` | string | Tenant name. |
+| `segmentId` | string | Segment identifier. |
+| `groupId` | string | IAM group identifier. |
+
+#### Response body
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `segmentId` | string | Segment identifier. |
+| `group` | object | Assigned group data. |
+| `group.id` | string | Group identifier. |
+| `group.name` | object | Localized group name. |
+| `mixins` | object | Assignment mixins. |
+| `metadata` | object | Assignment metadata. |
+
+#### Responses
+
+| Status | Description |
+| --- | --- |
+| `200 OK` | Returns the assignment. |
+| `404 Not Found` | The assignment does not exist. |
+| `403 Forbidden` | The caller does not have the required scope. |
+
+### List group assignments
+
+`GET /{tenant}/segments/{segmentId}/groups`
+
+Returns group assignments for the specified segment.
+
+**Required scope:** `segment.segment_read`
+
+#### Path parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `tenant` | string | Tenant name. |
+| `segmentId` | string | Segment identifier. |
+
+#### Query parameters and headers
+
+Supports the standard assignment collection parameters and headers, including paging, sorting, filtering with `q`, field selection, and the `X-Total-Count` response header.
+
+#### Responses
+
+| Status | Description |
+| --- | --- |
+| `200 OK` | Returns a list of group assignments. |
+| `403 Forbidden` | The caller does not have the required scope. |
+
+### Search group assignments
+
+`POST /{tenant}/segments/{segmentId}/groups/search`
+
+Searches group assignments for the specified segment.
+
+**Required scope:** `segment.segment_read`
+
+#### Path parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `tenant` | string | Tenant name. |
+| `segmentId` | string | Segment identifier. |
+
+#### Request body
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `q` | string | Filter expression, for example `group.id:groupId1`. |
+
+#### Responses
+
+| Status | Description |
+| --- | --- |
+| `200 OK` | Returns matching group assignments. |
+| `403 Forbidden` | The caller does not have the required scope. |
+
+### Delete a group assignment
+
+`DELETE /{tenant}/segments/{segmentId}/groups/{groupId}`
+
+Deletes the group assignment if it exists.
+
+**Required scope:** `segment.segment_manage`
+
+#### Path parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `tenant` | string | Tenant name. |
+| `segmentId` | string | Segment identifier. |
+| `groupId` | string | IAM group identifier. |
+
+#### Responses
+
+| Status | Description |
+| --- | --- |
+| `204 No Content` | The assignment is deleted or does not exist. |
+| `403 Forbidden` | The caller does not have the required scope. |
+
+### Behavior notes
+
+- When a group is updated in IAM, the assignment stores the updated `group.name`.
+- If a group's `userType` changes to `EMPLOYEE`, all assignments for that group are removed.
+- If a group is deleted, all assignments for that group are removed.

--- a/companies-and-customers/customer-segments/api-reference/README.md
+++ b/companies-and-customers/customer-segments/api-reference/README.md
@@ -12,7 +12,7 @@ icon: rectangle-terminal
 Preview
 {% endhint %}
 
-Customer segments now support the `GROUP` assignment type. You can assign IAM customer groups to a customer segment. Only groups with `userType` set to `CUSTOMER` can be assigned.
+Customer segments support the `GROUP` assignment type. You can assign IAM customer groups to a customer segment. Only groups with `userType` set to `CUSTOMER` can be assigned.
 
 ### Upsert a group assignment
 
@@ -20,7 +20,7 @@ Customer segments now support the `GROUP` assignment type. You can assign IAM cu
 
 Creates or updates a group assignment for the specified segment.
 
-**Required scope:** `segment.segment_manage`
+**Required scope:** `customersegment.segment_manage`
 
 #### Path parameters
 
@@ -32,8 +32,6 @@ Creates or updates a group assignment for the specified segment.
 
 #### Request body
 
-Uses the same assignment payload as other segment assignment upsert endpoints.
-
 | Field | Type | Description |
 | --- | --- | --- |
 | `mixins` | object | Optional assignment mixins. |
@@ -43,10 +41,9 @@ Uses the same assignment payload as other segment assignment upsert endpoints.
 
 | Status | Description |
 | --- | --- |
-| `201 Created` | The assignment is created and the response returns a creation response body. |
+| `201 Created` | The assignment is created. |
 | `204 No Content` | The assignment is updated. |
-| `400 Bad Request` | The segment does not exist or the group `userType` is not `CUSTOMER`. |
-| `404 Not Found` | The group does not exist. |
+| `400 Bad Request` | The segment does not exist, the group does not exist, or the group `userType` is not `CUSTOMER`. |
 | `403 Forbidden` | The caller does not have the required scope. |
 
 ### Get a group assignment
@@ -55,7 +52,7 @@ Uses the same assignment payload as other segment assignment upsert endpoints.
 
 Returns a single group assignment.
 
-**Required scope:** `segment.segment_read`
+**Required scope:** `customersegment.segment_read`
 
 #### Path parameters
 
@@ -90,7 +87,7 @@ Returns a single group assignment.
 
 Returns group assignments for the specified segment.
 
-**Required scope:** `segment.segment_read`
+**Required scope:** `customersegment.segment_read`
 
 #### Path parameters
 
@@ -101,7 +98,7 @@ Returns group assignments for the specified segment.
 
 #### Query parameters and headers
 
-Supports the standard assignment collection parameters and headers, including paging, sorting, filtering with `q`, field selection, and the `X-Total-Count` response header.
+Supports paging, sorting, filtering with `q`, field selection with `fields`, and the `X-Total-Count` response header.
 
 #### Responses
 
@@ -116,7 +113,7 @@ Supports the standard assignment collection parameters and headers, including pa
 
 Searches group assignments for the specified segment.
 
-**Required scope:** `segment.segment_read`
+**Required scope:** `customersegment.segment_read`
 
 #### Path parameters
 
@@ -136,6 +133,7 @@ Searches group assignments for the specified segment.
 | Status | Description |
 | --- | --- |
 | `200 OK` | Returns matching group assignments. |
+| `400 Bad Request` | The search request is invalid. |
 | `403 Forbidden` | The caller does not have the required scope. |
 
 ### Delete a group assignment
@@ -144,7 +142,7 @@ Searches group assignments for the specified segment.
 
 Deletes the group assignment if it exists.
 
-**Required scope:** `segment.segment_manage`
+**Required scope:** `customersegment.segment_manage`
 
 #### Path parameters
 
@@ -166,3 +164,5 @@ Deletes the group assignment if it exists.
 - When a group is updated in IAM, the assignment stores the updated `group.name`.
 - If a group's `userType` changes to `EMPLOYEE`, all assignments for that group are removed.
 - If a group is deleted, all assignments for that group are removed.
+
+ 

--- a/companies-and-customers/customer-segments/api-reference/api.yml
+++ b/companies-and-customers/customer-segments/api-reference/api.yml
@@ -15,6 +15,8 @@ tags:
     description: Manage customer assignments to segments
   - name: Items Assignments
     description: Manage item assignments to segments
+  - name: Group Assignments
+    description: Manage group assignments to segments
 paths:
   '/customer-segment/{tenant}/segments':
     parameters:
@@ -824,6 +826,174 @@ paths:
           $ref: '#/components/responses/Common_response_Unauthorized_401'
         '403':
           $ref: '#/components/responses/Common_response_Forbidden_403'
+  '/customer-segment/{tenant}/segments/{segmentId}/groups':
+    parameters:
+      - $ref: '#/components/parameters/tenant'
+      - $ref: '#/components/parameters/segmentId'
+    get:
+      summary: 'Retrieving all group assignments for a customer segment'
+      tags:
+        - Group Assignments
+      description: |
+        
+        **PREVIEW**
+
+        Retrieves all group assignments for a given customer segment.
+      security:
+        - CustomerAccessToken: 
+            - customersegment.segment_read
+      responses:
+        '200':
+          description: Group assignments for a customer segment were successfully retrieved.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GroupAssignmentResponse'
+        '401':
+          $ref: '#/components/responses/Common_response_Unauthorized_401'
+        '403':
+          $ref: '#/components/responses/Common_response_Forbidden_403'
+      operationId: GET-customer-segment-retrieve-groups
+      parameters:
+        - $ref: '#/components/parameters/qParam'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/pageNumber'
+        - $ref: '#/components/parameters/sort'
+        - $ref: '#/components/parameters/fields'
+        - $ref: '#/components/parameters/xTotalCount'
+  '/customer-segment/{tenant}/segments/{segmentId}/groups/search':
+    parameters:
+      - $ref: '#/components/parameters/tenant'
+      - $ref: '#/components/parameters/segmentId'
+    post:
+      summary: 'Searching with parameters for group assignments'
+      tags:
+        - Group Assignments
+      description: |
+        
+        **PREVIEW**
+
+        Returns all group assignments that match provided criteria.
+      security:
+        - CustomerAccessToken: 
+            - customersegment.segment_read
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SegmentsSearch'
+            example:
+              q: "group.id:groupId1"
+      responses:
+        '200':
+          description: Group assignments for a customer segment were successfully retrieved.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GroupAssignmentResponse'
+        '400':
+          $ref: '#/components/responses/Common_response_BadRequest_400'
+        '401':
+          $ref: '#/components/responses/Common_response_Unauthorized_401'
+        '403':
+          $ref: '#/components/responses/Common_response_Forbidden_403'
+      operationId: POST-customer-segment-search-groups
+      parameters:
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/pageNumber'
+        - $ref: '#/components/parameters/sort'
+        - $ref: '#/components/parameters/fields'
+        - $ref: '#/components/parameters/xTotalCount'
+  '/customer-segment/{tenant}/segments/{segmentId}/groups/{groupId}':
+    parameters:
+      - $ref: '#/components/parameters/tenant'
+      - $ref: '#/components/parameters/segmentId'
+      - $ref: '#/components/parameters/groupId'
+    get:
+      summary: 'Retrieving a group assignment for a customer segment'
+      tags:
+        - Group Assignments
+      description: |
+        
+        **PREVIEW**
+
+        Retrieves a group assignment for a given customer segment.
+      security:
+        - CustomerAccessToken: 
+            - customersegment.segment_read
+      responses:
+        '200':
+          description: Group assignment for a customer segment was successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupAssignmentResponse'
+        '401':
+          $ref: '#/components/responses/Common_response_Unauthorized_401'
+        '403':
+          $ref: '#/components/responses/Common_response_Forbidden_403'
+        '404':
+          $ref: '#/components/responses/Common_response_NotFound_404'
+      operationId: GET-customer-segment-retrieve-group
+      parameters:
+        - $ref: '#/components/parameters/fields'
+    put:
+      summary: 'Updating a group assignment for a customer segment'
+      tags:
+        - Group Assignments
+      operationId: PUT-customer-segment-update-group
+      description: |
+        
+        **PREVIEW**
+
+        Performs `UPSERT` operation. Updates a group assigned to a customer segment. A new group assignment is created if it's not present in the system.
+
+        Only groups with `userType` equal to `CUSTOMER` can be assigned to segments.
+      security:
+        - CustomerAccessToken: 
+            - customersegment.segment_manage
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupAssignmentUpsert'
+      responses:
+        '201':
+          description: A new group assignment was successfully created.
+        '204':
+          description: Group assignment was successfully updated.
+        '400':
+          $ref: '#/components/responses/Common_response_BadRequest_400'
+        '401':
+          $ref: '#/components/responses/Common_response_Unauthorized_401'
+        '403':
+          $ref: '#/components/responses/Common_response_Forbidden_403'
+        '404':
+          $ref: '#/components/responses/Common_response_NotFound_404'
+    delete:
+      summary: 'Removing a group from customer segment'
+      tags:
+        - Group Assignments
+      operationId: DELETE-customer-segment-remove-group
+      description: |
+        
+        **PREVIEW**
+
+        Removes group assignment.
+      security:
+        - CustomerAccessToken: 
+            - customersegment.segment_manage
+      responses:
+        '204':
+          description: Group assignment was successfully removed.
+        '401':
+          $ref: '#/components/responses/Common_response_Unauthorized_401'
+        '403':
+          $ref: '#/components/responses/Common_response_Forbidden_403'
   '/customer-segment/{tenant}/segments/items/category-trees':
     parameters:
       - $ref: '#/components/parameters/tenant'
@@ -1314,6 +1484,42 @@ components:
             legalEntity:
               $ref: '#/components/schemas/LegalEntity'
         - $ref: '#/components/schemas/CustomerAssignmentB2CResponse'
+    GroupAssignmentUpsert:
+      type: object
+      description: |
+        
+      properties:
+        mixins:
+          type: object
+          description: A key-value map of additional attributes.
+          additionalProperties: true
+        metadata:
+          $ref: '#/components/schemas/MetadataUpdate'
+    Group:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier of an existing group.
+        name:
+          type: object
+          description: Localized name of the group.
+          additionalProperties:
+            type: string
+    GroupAssignmentResponse:
+      allOf:
+        - type: object
+          properties:
+            segmentId:
+              type: string
+              description: Unique identifier of the customer segment.
+            group:
+              $ref: '#/components/schemas/Group'
+        - $ref: '#/components/schemas/GroupAssignmentUpsert'
+        - type: object
+          properties:
+            metadata:
+              $ref: '#/components/schemas/MetadataResponse'
     ItemAssignmentUpsert:
       type: object
       description: |
@@ -1636,6 +1842,13 @@ components:
       in: path
       required: true
       description: Unique identifier of the customer segment.
+      schema:
+        type: string
+    groupId:
+      name: groupId
+      in: path
+      required: true
+      description: Unique identifier of the group assigned to a customer segment.
       schema:
         type: string
     type:

--- a/companies-and-customers/customer-segments/api-reference/api.yml
+++ b/companies-and-customers/customer-segments/api-reference/api.yml
@@ -842,6 +842,7 @@ paths:
       security:
         - CustomerAccessToken: 
             - customersegment.segment_read
+            - customersegment.segment_read_own
       responses:
         '200':
           description: Group assignments for a customer segment were successfully retrieved.
@@ -863,6 +864,7 @@ paths:
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/fields'
         - $ref: '#/components/parameters/xTotalCount'
+        - $ref: '#/components/parameters/acceptLanguage'
   '/customer-segment/{tenant}/segments/{segmentId}/groups/search':
     parameters:
       - $ref: '#/components/parameters/tenant'
@@ -879,6 +881,7 @@ paths:
       security:
         - CustomerAccessToken: 
             - customersegment.segment_read
+            - customersegment.segment_read_own
       requestBody:
         content:
           application/json:
@@ -908,6 +911,7 @@ paths:
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/fields'
         - $ref: '#/components/parameters/xTotalCount'
+        - $ref: '#/components/parameters/acceptLanguage'
   '/customer-segment/{tenant}/segments/{segmentId}/groups/{groupId}':
     parameters:
       - $ref: '#/components/parameters/tenant'
@@ -925,6 +929,7 @@ paths:
       security:
         - CustomerAccessToken: 
             - customersegment.segment_read
+            - customersegment.segment_read_own
       responses:
         '200':
           description: Group assignment for a customer segment was successfully retrieved.
@@ -941,6 +946,7 @@ paths:
       operationId: GET-customer-segment-retrieve-group
       parameters:
         - $ref: '#/components/parameters/fields'
+        - $ref: '#/components/parameters/acceptLanguage'
     put:
       summary: 'Updating a group assignment for a customer segment'
       tags:
@@ -964,6 +970,14 @@ paths:
       responses:
         '201':
           description: A new group assignment was successfully created.
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    type: string
+              example:
+                id: 628cd20c6e8b2432b6346ca6
         '204':
           description: Group assignment was successfully updated.
         '400':
@@ -972,8 +986,6 @@ paths:
           $ref: '#/components/responses/Common_response_Unauthorized_401'
         '403':
           $ref: '#/components/responses/Common_response_Forbidden_403'
-        '404':
-          $ref: '#/components/responses/Common_response_NotFound_404'
     delete:
       summary: 'Removing a group from customer segment'
       tags:

--- a/companies-and-customers/customer-segments/segments.md
+++ b/companies-and-customers/customer-segments/segments.md
@@ -182,6 +182,86 @@ curl -i -X PUT
 Note that this operation performs an `UPSERT` operation. The `UPSERT` means that if a customer is already assigned to a segment, the assignment gets updated. If not, the customer assignment is created in the system.
 {% endhint %}
 
+### Add groups to a segment
+
+{% hint style="warning" %}
+The group assignment endpoints are currently in **PREVIEW**.
+{% endhint %}
+
+You can also assign IAM groups to a customer segment.
+
+* To add or update a group assignment, send the request to the [Updating a group assignment](https://developer.emporix.io/api-references/api-guides/companies-and-customers/customer-segments/api-reference/groups-assignments#put-customer-segment-tenant-segments-segmentid-groups-groupid) endpoint. You need the `customersegment.segment_manage` scope.
+
+{% include "../../.gitbook/includes/example-hint-text.md" %}
+
+{% content-ref url="../customer-segments/api-reference/" %}
+[api-reference](../customer-segments/api-reference/)
+{% endcontent-ref %}
+
+```bash
+curl -i -X PUT
+  'https://api.emporix.io/customer-segment/{tenant}/segments/{segmentId}/groups/{groupId}'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
+  -H 'Content-Type: application/json'
+  -d '{
+    "mixins": {
+      "segmentAttributes": {
+        "membershipStatus": "PREMIUM"
+      }
+    },
+    "metadata": {
+      "mixins": {
+        "segmentAttributes": "https://res.cloudinary.com/saas-ag/raw/upload/emporix-docs/69537caeb3fd5d378296ae42_segmentAttributes.json"
+      }
+    }
+  }'
+```
+
+The operation performs an `UPSERT`. If the group is already assigned to the segment, the assignment is updated. Otherwise, a new assignment is created.
+
+Only IAM groups with `userType=CUSTOMER` can be assigned to segments.
+
+* To retrieve all group assignments for a segment, send the request to the [Retrieving group assignments](https://developer.emporix.io/api-references/api-guides/companies-and-customers/customer-segments/api-reference/groups-assignments#get-customer-segment-tenant-segments-segmentid-groups) endpoint. You need the `customersegment.segment_read` scope. You can use paging, sorting, `fields`, and the `q` query parameter.
+
+```bash
+curl -i -X GET
+  'https://api.emporix.io/customer-segment/{tenant}/segments/{segmentId}/groups?q=group.id:groupId1&pageSize=1&pageNumber=1&sort=group.id:ASC&fields=group,metadata'
+  -H 'Accept-Language: string'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
+  -H 'X-Total-Count: true'
+```
+
+* To search group assignments within a segment, send the request to the [Searching group assignments](https://developer.emporix.io/api-references/api-guides/companies-and-customers/customer-segments/api-reference/groups-assignments#post-customer-segment-tenant-segments-segmentid-groups-search) endpoint. You need the `customersegment.segment_read` scope.
+
+```bash
+curl -i -X POST
+  'https://api.emporix.io/customer-segment/{tenant}/segments/{segmentId}/groups'
+  -H 'Accept-Language: string'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
+  -H 'Content-Type: application/json'
+  -H 'X-Total-Count: true'
+  -d '{
+    "q": "group.id:groupId1"
+  }'
+```
+
+* To retrieve a specific group assignment, send the request to the [Retrieving a group assignment](https://developer.emporix.io/api-references/api-guides/companies-and-customers/customer-segments/api-reference/groups-assignments#get-customer-segment-tenant-segments-segmentid-groups-groupid) endpoint. You need the `customersegment.segment_read` scope.
+
+```bash
+curl -i -X GET
+  'https://api.emporix.io/customer-segment/{tenant}/segments/{segmentId}/groups/{groupId}'
+  -H 'Accept-Language: string'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
+```
+
+* To remove a group assignment from a segment, send the request to the [Deleting a group assignment](https://developer.emporix.io/api-references/api-guides/companies-and-customers/customer-segments/api-reference/groups-assignments#delete-customer-segment-tenant-segments-segmentid-groups-groupid) endpoint. You need the `customersegment.segment_manage` scope.
+
+```bash
+curl -i -X DELETE
+  'https://api.emporix.io/customer-segment/{tenant}/segments/{segmentId}/groups/{groupId}'
+  -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
+```
+
 ## How to find a specific segment using search parameters
 
 {% hint style="warning" %}

--- a/companies-and-customers/customer-segments/segments.md
+++ b/companies-and-customers/customer-segments/segments.md
@@ -221,6 +221,8 @@ The operation performs an `UPSERT`. If the group is already assigned to the segm
 
 Only IAM groups with `userType=CUSTOMER` can be assigned to segments.
 
+The first upsert returns `201 Created`. Updating an existing assignment returns `204 No Content`.
+
 * To retrieve all group assignments for a segment, send the request to the [Retrieving group assignments](https://developer.emporix.io/api-references/api-guides/companies-and-customers/customer-segments/api-reference/groups-assignments#get-customer-segment-tenant-segments-segmentid-groups) endpoint. You need the `customersegment.segment_read` scope. You can use paging, sorting, `fields`, and the `q` query parameter.
 
 ```bash
@@ -235,7 +237,7 @@ curl -i -X GET
 
 ```bash
 curl -i -X POST
-  'https://api.emporix.io/customer-segment/{tenant}/segments/{segmentId}/groups'
+  'https://api.emporix.io/customer-segment/{tenant}/segments/{segmentId}/groups/search'
   -H 'Accept-Language: string'
   -H 'Authorization: Bearer {{OAUTH2_ACCESS_TOKEN}}'
   -H 'Content-Type: application/json'

--- a/webhooks/events-customer-segment.md
+++ b/webhooks/events-customer-segment.md
@@ -50,6 +50,31 @@ description: Webhook events related to the creation, update, and deletion of cus
   "segmentId": "String",
   "tenant": "String"
 }
+</code></pre></td></tr><tr><td>customer-segment.group-assignment-created</td><td><pre class="language-json"><code class="lang-json">{
+  "group": {
+    "id": "String",
+    "name": "Map"
+  },
+  "metadata": {},
+  "mixins": "Map",
+  "segmentId": "String",
+  "tenant": "String"
+}
+</code></pre></td></tr><tr><td>customer-segment.group-assignment-deleted</td><td><pre class="language-json"><code class="lang-json">{
+  "groupId": "String",
+  "segmentId": "String",
+  "tenant": "String"
+}
+</code></pre></td></tr><tr><td>customer-segment.group-assignment-updated</td><td><pre class="language-json"><code class="lang-json">{
+  "group": {
+    "id": "String",
+    "name": "Map"
+  },
+  "metadata": {},
+  "mixins": "Map",
+  "segmentId": "String",
+  "tenant": "String"
+}
 </code></pre></td></tr><tr><td>customer-segment.item-assignment-created</td><td><pre class="language-json"><code class="lang-json">{
   "item": {
     "code": "String",

--- a/webhooks/events-customer-segment.md
+++ b/webhooks/events-customer-segment.md
@@ -50,7 +50,7 @@ description: Webhook events related to the creation, update, and deletion of cus
   "segmentId": "String",
   "tenant": "String"
 }
-</code></pre></td></tr><tr><td>customer-segment.group-assignment-created</td><td><pre class="language-json"><code class="lang-json">{
+</code></pre></td></tr><tr><td>customer-segment.segment-group-assignment-created</td><td><pre class="language-json"><code class="lang-json">{
   "group": {
     "id": "String",
     "name": "Map"
@@ -60,12 +60,12 @@ description: Webhook events related to the creation, update, and deletion of cus
   "segmentId": "String",
   "tenant": "String"
 }
-</code></pre></td></tr><tr><td>customer-segment.group-assignment-deleted</td><td><pre class="language-json"><code class="lang-json">{
+</code></pre></td></tr><tr><td>customer-segment.segment-group-assignment-deleted</td><td><pre class="language-json"><code class="lang-json">{
   "groupId": "String",
   "segmentId": "String",
   "tenant": "String"
 }
-</code></pre></td></tr><tr><td>customer-segment.group-assignment-updated</td><td><pre class="language-json"><code class="lang-json">{
+</code></pre></td></tr><tr><td>customer-segment.segment-group-assignment-updated</td><td><pre class="language-json"><code class="lang-json">{
   "group": {
     "id": "String",
     "name": "Map"


### PR DESCRIPTION
Auto-generated by **Emporix AI Buddy** for feature `ac24be53-666b-418a-9e17-32b82a19b584` (COP-6041).

## Changed files

- `companies-and-customers/customer-segments/api-reference/api.yml`
- `companies-and-customers/customer-segments/api-reference/README.md`
- `companies-and-customers/customer-segments/segments.md`
- `webhooks/events-customer-segment.md`

## Review summary

1 of 4 files is approved; 3 need revision. The main issues are accuracy and completeness gaps in the customer-segment docs: one incorrect duplicate endpoint was introduced, the new `GROUP` assignment type was not consistently called out, create-vs-update upsert responses were documented imprecisely, and required scopes, filtering, and language-related request details were missing from examples. Cross-file consistency is currently uneven, especially around PREVIEW marking, endpoint set, and request/response behavior, while the webhook event documentation is aligned with the implementation. Overall, the batch covers the feature directionally, but it does not yet adequately document the customer-segment public contract without another correction pass. After the revision round, 1 file(s) approved, 3 still flagged.

> ⚠️ Review all changes carefully before merging. The AI proposal may need manual adjustments.