### PR TITLE
docs: API reference updates — [BE] Extend Schema Service to support mixin schemas for Location and Availability

### DIFF
--- a/standard-practices/mixins.md
+++ b/standard-practices/mixins.md
@@ -33,7 +33,9 @@ These entities support mixin schema creation through the [Schema Service API](..
 - **Customer** - Customer Service / Customer Management Service
 - **Media** - Media Service
 - **Customer Address** - Customer Service
+- **Location** - Vendor Service
 - **Order** - Order Service
+- **Availability** - Availability Service
 - **Price List** - Price Service
 - **Product** - Product Service
 - **Quote** - Quote Service
@@ -43,11 +45,9 @@ These entities support mixin schema creation through the [Schema Service API](..
 
 ### Additional mixin support 
 These services accept mixins in their API requests and responses, but require manually created JSON schemas (not supported through Schema Service schema creation):
-- **Availability** - Availability Service
 - **Customer and Item Assignments** - Customer Segments Service
 - **Customer Segments** - Customer Segments Service
 - **Groups** - IAM Service (supports `mixins` field directly, without `metadata.mixins`)
-- **Locations** - Vendor Service
 - **Locations and Contact Assignment** - Client Management Service 
 - **Prices** - Price Service
 - **Returns** - Returns Service

--- a/utilities/schema/api-reference/api.yml
+++ b/utilities/schema/api-reference/api.yml
@@ -372,6 +372,7 @@ paths:
               SchemaTypes:
                 value:
                   - PRODUCT
+                  - ORDER
                   - AVAILABILITY
         description: ''
       responses:

--- a/utilities/schema/api-reference/api.yml
+++ b/utilities/schema/api-reference/api.yml
@@ -226,7 +226,7 @@ paths:
         - name: type
           in: query
           description: |
-            Filters schemas by type. Possible types to specify, CART, CART_ITEM, CATEGORY, COMPANY, COUPON, CUSTOMER, CUSTOMER_ADDRESS, ORDER, ORDER_ENTRY, PRODUCT, QUOTE, RETURN, PRICE_LIST, SITE, CUSTOM_ENTITY, VENDOR, MEDIA. When the newest version of the schema is of different type than the previous one and the previous one matches the type specified in this query param, then the previous version is returned.
+            Filters schemas by type. Possible types to specify, AVAILABILITY, CART, CART_ITEM, CATEGORY, COMPANY, COUPON, CUSTOMER, CUSTOMER_ADDRESS, LOCATION, ORDER, ORDER_ENTRY, PRODUCT, QUOTE, RETURN, PRICE_LIST, SITE, CUSTOM_ENTITY, VENDOR, MEDIA. When the newest version of the schema is of different type than the previous one and the previous one matches the type specified in this query param, then the previous version is returned.
           # DEV NOTE: If you add another type, the tutorial and MD guides have to be updated as well.
           schema:
             type: string
@@ -372,7 +372,7 @@ paths:
               SchemaTypes:
                 value:
                   - PRODUCT
-                  - ORDER
+                  - AVAILABILITY
         description: ''
       responses:
         '204':
@@ -462,6 +462,8 @@ paths:
               examples:
                 Types:
                   value:
+                    - AVAILABILITY
+                    - LOCATION
                     - ORDER
                     - PRODUCT
                     - QUOTE
@@ -583,7 +585,7 @@ paths:
         - name: type
           in: query
           description: |
-            Filters references by type. Possible types to specify, CART, CART_ITEM, CATEGORY, COMPANY, COUPON, CUSTOMER, CUSTOMER_ADDRESS, ORDER, ORDER_ENTRY, PRODUCT, QUOTE, RETURN, PRICE_LIST, SITE, CUSTOM_ENTITY, VENDOR, MEDIA. When the newer version of a reference is of different type than the previous one and the previous one matches the type specified in this query param, then the previous version is returned.
+            Filters references by type. Possible types to specify, AVAILABILITY, CART, CART_ITEM, CATEGORY, COMPANY, COUPON, CUSTOMER, CUSTOMER_ADDRESS, LOCATION, ORDER, ORDER_ENTRY, PRODUCT, QUOTE, RETURN, PRICE_LIST, SITE, CUSTOM_ENTITY, VENDOR, MEDIA. When the newer version of a reference is of different type than the previous one and the previous one matches the type specified in this query param, then the previous version is returned.
           schema:
             type: string
   '/schema/{tenant}/references/{id}':
@@ -699,6 +701,8 @@ paths:
         Creates a custom type entity that can be later used for creating custom instances.
 
         **Note**: When a custom entity type is created, a set of custom scopes is created, which allow managing custom instances of that type.
+
+        Reserved built-in type IDs cannot be used as custom schema type IDs. This includes AVAILABILITY and LOCATION.
 
       operationId: POST-schema-create-custom-schema-type
       requestBody:

--- a/utilities/schema/schema.md
+++ b/utilities/schema/schema.md
@@ -12,10 +12,10 @@ With the Schema Service you can easily create and manage customized/industry-spe
 
 ## Supported entity types for schema creation
 
-When creating a mixin schema through the Schema Service API, you can select from the following entity types: `cart`, `cart_item`, `category`, `company`, `coupon`, `customer`, `customer_address`, `custom_entity`, `media`, `order`, `order_entry`, `price_list`, `product`, `quote`, `return`, `site`, and `vendor`.
+When creating a mixin schema through the Schema Service API, you can select from the following entity types: `availability`, `cart`, `cart_item`, `category`, `company`, `coupon`, `customer`, `customer_address`, `custom_entity`, `location`, `media`, `order`, `order_entry`, `price_list`, `product`, `quote`, `return`, `site`, and `vendor`.
 
 {% hint style="info" %}
-**Important distinction:** The list above shows which entity types support mixin schema creation through the Schema Service API. However, many additional APIs accept mixins in their requests and responses even though you cannot create schemas for them through this service. For example, the Order API, Checkout API, Availability API, and Shopping List API all support mixins, but you need to create mixin schemas manually (as JSON schemas) and reference them when using those APIs. See the [Mixins standard practices](../../standard-practices/mixins.md) page for a complete list of APIs that support mixins.
+**Important distinction:** The list above shows which entity types support mixin schema creation through the Schema Service API. APIs that support mixins but are not listed there still require you to create mixin schemas manually (as JSON schemas) and reference them when using those APIs. See the [Mixins standard practices](../../standard-practices/mixins.md) page for a complete list of APIs that support mixins.
 {% endhint %}
 
 ## How to add custom fields for an entity


### PR DESCRIPTION
Auto-generated by **Emporix AI Buddy** for feature `3037cdbc-a8d3-4496-9d2a-1358f83398dd` (COP-6051).

## Changed files

- `utilities/schema/api-reference/api.yml`
- `utilities/schema/schema.md`
- `standard-practices/mixins.md`

## Review summary

1 of 3 files is approved, while 2 need revision. The main issues are incomplete coverage in the OpenAPI-facing documentation and wording that goes beyond the confirmed feature scope. Across files, the core change is handled consistently—Availability and Location are treated as supported schema entity types—but `utilities/schema/api-reference/api.yml` still needs all visible allowed-type and reserved-id guidance updated, and `standard-practices/mixins.md` should keep its note generic. Overall, the batch is close but does not yet adequately cover the feature end to end because the API reference remains partially updated. After the revision round, 2 file(s) approved, 1 still flagged.

> ⚠️ Review all changes carefully before merging. The AI proposal may need manual adjustments.