### PR TITLE
import-service: document force run flag + ImportedRecord.targetId

### DIFF
--- a/utilities/import-service/api-reference/api.yml
+++ b/utilities/import-service/api-reference/api.yml
@@ -312,8 +312,7 @@ paths:
                 force:
                   type: boolean
                   description: >-
-                    When `true`, every extracted record is re-written even if unchanged (bypasses the
-                    idempotency skip-if-unchanged check). Use to force target ids/values to be re-written.
+                    When `true`, every extracted record is rewritten, even if unchanged. It bypasses the idempotency `skip-if-unchanged` check. Use it to force target IDs and values to be rewritten.
                   example: false
             examples:
               Full run:
@@ -1125,8 +1124,8 @@ components:
         targetId:
           type: string
           description: >-
-            The deterministic Emporix instance id the record was written under (derived from the natural
-            key), so the record can be located in the target.
+            The deterministic Emporix instance ID the record was written under. It's derived from the natural
+            key and allows the record to be located in the target.
           example: id-sku-1001
         fields:
           type: object

--- a/utilities/import-service/api-reference/api.yml
+++ b/utilities/import-service/api-reference/api.yml
@@ -309,6 +309,12 @@ paths:
                   type: boolean
                   description: When `true`, the run maps and validates but performs no remote writes.
                   example: false
+                force:
+                  type: boolean
+                  description: >-
+                    When `true`, every extracted record is re-written even if unchanged (bypasses the
+                    idempotency skip-if-unchanged check). Use to force target ids/values to be re-written.
+                  example: false
             examples:
               Full run:
                 value:
@@ -1116,6 +1122,12 @@ components:
           type: string
           description: The source natural key.
           example: SKU-1001
+        targetId:
+          type: string
+          description: >-
+            The deterministic Emporix instance id the record was written under (derived from the natural
+            key), so the record can be located in the target.
+          example: id-sku-1001
         fields:
           type: object
           description: The stored fields.


### PR DESCRIPTION
Two public (trigger-scope) import-tool API additions:

- **`force`** — optional boolean on the `triggerRun` request body (`POST /importtool/{tenant}/configs/{configId}/runs`). Re-writes every extracted record even if unchanged (bypasses the idempotency skip). Ships in importtool #63.
- **`targetId`** — new field on the `ImportedRecord` response schema (returned by the data-record endpoints): the deterministic Emporix instance id the record was written under. Ships in importtool #59 (merged).

Both are additive/optional. Mirrors the importtool repo specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)