### PR TITLE
docs: API reference updates — Sub-task 1: Multiple per-event-type targets in the config model + API

### DIFF
--- a/webhooks/webhook-service/api-reference/api.yml
+++ b/webhooks/webhook-service/api-reference/api.yml
@@ -43,6 +43,8 @@ paths:
         **NOTE**
         At any time, a tenant can have only one webhook configuration of each type: `svix`, `svix_shared`, and `http`. If a configuration of the requested type already exists, the request returns a `409 Conflict` response. To change the configuration, update or delete the existing one.
 
+        For HTTP configurations, `eventsConfiguration` can contain multiple entries for the same `eventType`. The server assigns a stable `id` to each entry. Client-supplied entry ids on create are rejected.
+
         **NOTE**
         Svix supports a maximum message payload size of approximately 350kb. However, it is generally advisable to keep webhook payloads small, ideally under 40kb. For larger message sizes, consider using the HTTP Webhook Strategy.
       operationId: POST-webhook-create-config
@@ -136,6 +138,11 @@ paths:
 
         * Svix Emporix Shared Account
         * Svix Custom Account
+        * HTTP Webhook Strategy
+
+        For HTTP configurations, `eventsConfiguration` can contain multiple entries for the same `eventType`. Each entry is identified by a stable `id`.
+
+        Existing entry ids must be preserved on update. Legacy payloads without entry ids are still accepted and the server assigns ids to id-less entries.
       operationId: PUT-webhook-update-config
       security:
         - OAuth2:
@@ -552,6 +559,8 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/EventConfiguration'
+      description: List of HTTP event-specific configuration entries. Multiple entries for the same `eventType` are allowed. Duplicate entry ids are rejected. The maximum number of entries per event type is limited by the service configuration.
+
     HttpHeaderConfigValue:
       type: object
       properties:


### PR DESCRIPTION
Auto-generated by **Emporix AI Buddy** for feature `cd5a10da-e7fb-4744-824a-c8bba3155d0b` (COP-6177).

## Changed files

- `webhooks/webhook-service/api-reference/api.yml`

## Review summary

0 of 2 files are approved; both need revision before the batch is ready. The main issues are accuracy gaps rather than structure problems: missing concrete PATCH path details, incomplete validation/error documentation, outdated PUT/provider wording, and overstatements around ID generation for legacy id-less configs. Cross-file consistency is only partial, since both files cover the new multi-entry model but neither fully aligns with the implemented PATCH contract and backward-compatibility caveats. As it stands, the batch covers the feature directionally, but it does not yet adequately document the full client-facing contract for this change. After the revision round, 0 file(s) approved, 2 still flagged.

> ⚠️ Review all changes carefully before merging. The AI proposal may need manual adjustments.